### PR TITLE
chore: version bump to `2.7.x`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,9 @@
 
 	<PropertyGroup Label="Versioning">
 		<VersionMajor>2</VersionMajor>
-		<VersionMinor>6</VersionMinor>
+		<VersionMinor>7</VersionMinor>
 		<VersionPatch>$([System.DateTime]::UtcNow.ToString("MMdd"))</VersionPatch>
-		<VersionRevision>$([System.DateTime]::UtcNow.TimeOfDay.TotalMinutes.ToString("0"))</VersionRevision>
+		<VersionRevision>$([System.DateTime]::UtcNow.TimeOfDay.TotalHours.ToString("0"))</VersionRevision>
 		<VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch).$(VersionRevision)</VersionPrefix>
 		<VersionSuffix Condition="$(Configuration.Equals('Debug'))">Development</VersionSuffix>
 		<FileVersion>$(VersionMajor).$(VersionMinor).$(VersionPatch)</FileVersion>


### PR DESCRIPTION
changes:
- [chore: version bump to 2.7.x](https://github.com/BoBoBaSs84/BB84.Extensions/commit/32d102e064ce62b1ad6bf529e2d21e8abedc3aa9)

closes #140 