### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/BB84.Extensions/security/code-scanning/6](https://github.com/BoBoBaSs84/BB84.Extensions/security/code-scanning/6)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only checks out code and runs build/test steps, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow file (above `jobs:`), so it applies to all jobs unless overridden. Edit `.github/workflows/ci.yml` to insert the following block after the workflow name and before the `on:` block:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
