### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: write
+      packages: write
     runs-on: windows-latest
 
     steps:
@@ -26,6 +29,8 @@ jobs:
         dotnet-releaser run --nuget-token "${{secrets.NUGET_TOKEN}}" --github-token "${{secrets.GITHUB_TOKEN}}" dotnet-releaser.toml
 
   docs:
+    permissions:
+      contents: write
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/BB84.Extensions/security/code-scanning/8](https://github.com/BoBoBaSs84/BB84.Extensions/security/code-scanning/8)

To fix the problem, we should add a `permissions` block to each job in the workflow, specifying only the permissions required for that job. For the `publish` job, which publishes NuGet packages and interacts with GitHub releases, it likely needs `contents: write` and possibly `packages: write` and `pull-requests: write` if it creates or updates pull requests. For the `docs` job, which deploys documentation using `peaceiris/actions-gh-pages`, it needs `contents: write` to push to the `gh-pages` branch. The minimal permissions should be set for each job, directly under the job name (at the same level as `runs-on`). No changes to the steps or other workflow logic are required.