### PR TITLE
feat: Add FlagsCheckBox and FlagsRadioButton controls

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+		<PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="MSTest" Version="4.1.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />

--- a/src/BB84.WinForms.Extensions/BB84.WinForms.Extensions.csproj
+++ b/src/BB84.WinForms.Extensions/BB84.WinForms.Extensions.csproj
@@ -14,4 +14,8 @@
 		<PackageTags>library;csharp;extensions;winforms</PackageTags>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<PackageReference Include="System.ComponentModel.Annotations" />
+	</ItemGroup>
+
 </Project>

--- a/src/BB84.WinForms.Extensions/Controls/FlagsCheckBox.Designer.cs
+++ b/src/BB84.WinForms.Extensions/Controls/FlagsCheckBox.Designer.cs
@@ -1,0 +1,61 @@
+namespace BB84.WinForms.Extensions.Controls
+{
+    partial class FlagsCheckBox
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            flowLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
+            SuspendLayout();
+            // 
+            // flowLayoutPanel
+            // 
+            flowLayoutPanel.AutoScroll = true;
+            flowLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            flowLayoutPanel.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            flowLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            flowLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
+            flowLayoutPanel.Name = "flowLayoutPanel";
+            flowLayoutPanel.Size = new System.Drawing.Size(200, 150);
+            flowLayoutPanel.TabIndex = 0;
+            flowLayoutPanel.WrapContents = false;
+            // 
+            // FlagsCheckBoxControl
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(flowLayoutPanel);
+            Name = "FlagsCheckBoxControl";
+            Size = new System.Drawing.Size(200, 150);
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel;
+    }
+}

--- a/src/BB84.WinForms.Extensions/Controls/FlagsCheckBox.cs
+++ b/src/BB84.WinForms.Extensions/Controls/FlagsCheckBox.cs
@@ -1,0 +1,341 @@
+using System.ComponentModel;
+using System.Globalization;
+
+namespace BB84.WinForms.Extensions.Controls;
+
+/// <summary>
+/// Represents a user control that displays a set of check boxes for selecting multiple values
+/// of an enum type marked with the <see cref="FlagsAttribute"/>.
+/// </summary>
+/// <remarks>
+/// Use to bind to an enum type with the <see cref="FlagsAttribute"/>, allowing users to select
+/// one or more flags. The control requires the enum to define a zero-valued flag to represent no
+/// selection.
+/// </remarks>
+[DefaultBindingProperty(nameof(SelectedValue))]
+public partial class FlagsCheckBox : UserControl
+{
+	private Type? _enumType;
+	private Enum? _selectedValue;
+	private Enum? _zeroValue;
+	private bool _zeroValueDefined;
+	private bool _isUpdatingSelection;
+	private FlowDirection _flowDirection = FlowDirection.LeftToRight;
+	private Func<Enum, string>? _displayNameResolver;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="FlagsCheckBox"/> control.
+	/// </summary>
+	public FlagsCheckBox()
+	{
+		InitializeComponent();
+		ApplyFlowDirection();
+	}
+
+	/// <summary>
+	/// Gets or sets the layout direction used by the internal flow layout panel.
+	/// </summary>
+	[Category("Layout")]
+	[Description("Determines the layout direction used to arrange the check boxes.")]
+	[DefaultValue(FlowDirection.LeftToRight)]
+	public FlowDirection FlowDirection
+	{
+		get => flowLayoutPanel?.FlowDirection ?? _flowDirection;
+		set
+		{
+			if (_flowDirection == value)
+				return;
+
+			_flowDirection = value;
+			ApplyFlowDirection();
+		}
+	}
+
+	/// <summary>
+	/// Gets or sets the delegate used to produce display names for each flag value.
+	/// </summary>
+	[Browsable(false)]
+	[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+	public Func<Enum, string>? DisplayNameResolver
+	{
+		get => _displayNameResolver;
+		set
+		{
+			if (_displayNameResolver == value)
+				return;
+
+			_displayNameResolver = value;
+			UpdateDisplayNames();
+		}
+	}
+
+	/// <summary>
+	/// Gets or sets the enum type that defines the flags to be displayed as check boxes.
+	/// </summary>
+	[Browsable(false)]
+	[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+	public Type? EnumType
+	{
+		get => _enumType;
+		set => SetEnumType(value);
+	}
+
+	/// <summary>
+	/// Gets or sets the currently selected value, which is a combination of the enum flags
+	/// represented by the check boxes.
+	/// </summary>
+	[Browsable(false)]
+	[Bindable(true)]
+	[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+	public Enum? SelectedValue
+	{
+		get => _selectedValue;
+		set
+		{
+			if (value is null)
+			{
+				SetSelectedValueToZero();
+				return;
+			}
+
+			if (_enumType is null)
+				EnumType = value.GetType();
+
+			if (value.GetType() != _enumType)
+				throw new ArgumentException($"Selected value must be of type {_enumType}.", nameof(value));
+
+			long numericValue = Convert.ToInt64(value, CultureInfo.InvariantCulture);
+			if (numericValue == 0 && !_zeroValueDefined)
+				throw new ArgumentException("Selected value cannot be zero because the enum does not define a zero-valued flag.", nameof(value));
+
+			Enum newValue = numericValue == 0 && _zeroValue is not null ? _zeroValue : value;
+
+			if (Equals(_selectedValue, newValue))
+				return;
+
+			_selectedValue = newValue;
+			UpdateCheckBoxesFromValue();
+			OnSelectedValueChanged(EventArgs.Empty);
+		}
+	}
+
+	/// <summary>
+	/// Occurs when the selected value changes.
+	/// </summary>
+	public event EventHandler? SelectedValueChanged;
+
+	/// <summary>
+	/// Is called when the selected value changes, either through user interaction or programmatically.
+	/// </summary>
+	/// <param name="e">The event data.</param>
+	protected virtual void OnSelectedValueChanged(EventArgs e)
+		=> SelectedValueChanged?.Invoke(this, e);
+
+	private void SetEnumType(Type? value)
+	{
+		if (value == _enumType)
+			return;
+
+		_zeroValueDefined = false;
+		_zeroValue = null;
+
+		if (value is not null)
+		{
+			if (!value.IsEnum)
+				throw new ArgumentException("EnumType must be an enum type.", nameof(value));
+
+			if (!Attribute.IsDefined(value, typeof(FlagsAttribute)))
+				throw new ArgumentException("EnumType must be decorated with FlagsAttribute.", nameof(value));
+
+			foreach (Enum enumValue in Enum.GetValues(value))
+			{
+				if (Convert.ToInt64(enumValue, CultureInfo.InvariantCulture) == 0)
+				{
+					_zeroValueDefined = true;
+					_zeroValue = enumValue;
+					break;
+				}
+			}
+
+			if (!_zeroValueDefined)
+				throw new ArgumentException("EnumType must define a zero-valued flag to represent no selection.", nameof(value));
+		}
+
+		_enumType = value;
+		BuildCheckBoxes();
+
+		if (_enumType is null)
+		{
+			if (_selectedValue is not null)
+			{
+				_selectedValue = null;
+				UpdateCheckBoxesFromValue();
+				OnSelectedValueChanged(EventArgs.Empty);
+			}
+			return;
+		}
+
+		if (_selectedValue is null || _selectedValue.GetType() != _enumType)
+		{
+			_selectedValue = _zeroValue;
+			UpdateCheckBoxesFromValue();
+			OnSelectedValueChanged(EventArgs.Empty);
+		}
+	}
+
+	private void BuildCheckBoxes()
+	{
+		if (flowLayoutPanel is null)
+			return;
+
+		flowLayoutPanel.SuspendLayout();
+		try
+		{
+			foreach (Control control in flowLayoutPanel.Controls)
+				control.Dispose();
+
+			flowLayoutPanel.Controls.Clear();
+
+			if (_enumType is null)
+				return;
+
+			foreach (Enum flagValue in Enum.GetValues(_enumType))
+			{
+				if (Convert.ToInt64(flagValue, CultureInfo.InvariantCulture) == 0)
+					continue;
+
+				var checkBox = new CheckBox
+				{
+					AutoSize = true,
+					Text = ResolveDisplayName(flagValue),
+					Tag = flagValue,
+					Margin = new Padding(3),
+				};
+
+				checkBox.CheckedChanged += HandleCheckBoxCheckedChanged;
+				flowLayoutPanel.Controls.Add(checkBox);
+			}
+		}
+		finally
+		{
+			flowLayoutPanel.ResumeLayout();
+		}
+
+		UpdateCheckBoxesFromValue();
+		UpdateDisplayNames();
+	}
+
+	private void HandleCheckBoxCheckedChanged(object? sender, EventArgs e)
+	{
+		if (_isUpdatingSelection)
+			return;
+
+		if (_enumType is null || sender is not CheckBox checkBox || checkBox.Tag is not Enum flagValue)
+			return;
+
+		long flagBits = Convert.ToInt64(flagValue, CultureInfo.InvariantCulture);
+
+		if (flagBits == 0)
+			return;
+
+		long currentBits = _selectedValue is not null
+			? Convert.ToInt64(_selectedValue, CultureInfo.InvariantCulture)
+			: 0;
+
+		long newBits = checkBox.Checked
+				? currentBits | flagBits
+				: currentBits & ~flagBits;
+
+		if (newBits == 0)
+		{
+			if (_zeroValue is not null)
+			{
+				SelectedValue = _zeroValue;
+			}
+			else
+			{
+				UpdateCheckBoxesFromValue();
+			}
+			return;
+		}
+
+		var newValue = (Enum)Enum.ToObject(_enumType, newBits);
+		SelectedValue = newValue;
+	}
+
+	private void UpdateCheckBoxesFromValue()
+	{
+		if (flowLayoutPanel is null)
+			return;
+
+		_isUpdatingSelection = true;
+		try
+		{
+			foreach (Control control in flowLayoutPanel.Controls)
+			{
+				if (control is CheckBox checkBox && checkBox.Tag is Enum value)
+				{
+					checkBox.Checked = IsFlagSet(_selectedValue, value);
+				}
+			}
+		}
+		finally
+		{
+			_isUpdatingSelection = false;
+		}
+	}
+
+	private void SetSelectedValueToZero()
+	{
+		if (!_zeroValueDefined || _zeroValue is null)
+		{
+			if (_selectedValue is not null)
+			{
+				_selectedValue = null;
+				UpdateCheckBoxesFromValue();
+				OnSelectedValueChanged(EventArgs.Empty);
+			}
+			return;
+		}
+
+		if (Equals(_selectedValue, _zeroValue))
+			return;
+
+		_selectedValue = _zeroValue;
+		UpdateCheckBoxesFromValue();
+		OnSelectedValueChanged(EventArgs.Empty);
+	}
+
+	private static bool IsFlagSet(Enum? currentValue, Enum flagValue)
+	{
+		if (currentValue is null)
+			return false;
+
+		long currentBits = Convert.ToInt64(currentValue, CultureInfo.InvariantCulture);
+		long flagBits = Convert.ToInt64(flagValue, CultureInfo.InvariantCulture);
+		return flagBits != 0 && (currentBits & flagBits) == flagBits;
+	}
+
+	private string ResolveDisplayName(Enum value)
+		=> _displayNameResolver?.Invoke(value) ?? value.ToString();
+
+	private void UpdateDisplayNames()
+	{
+		if (flowLayoutPanel is null)
+			return;
+
+		foreach (Control control in flowLayoutPanel.Controls)
+		{
+			if (control is CheckBox checkBox && checkBox.Tag is Enum value)
+				checkBox.Text = ResolveDisplayName(value);
+		}
+	}
+
+	private void ApplyFlowDirection()
+	{
+		if (flowLayoutPanel is null || flowLayoutPanel.FlowDirection == _flowDirection)
+			return;
+
+		flowLayoutPanel.FlowDirection = _flowDirection;
+	}
+}

--- a/src/BB84.WinForms.Extensions/Controls/FlagsCheckBox.resx
+++ b/src/BB84.WinForms.Extensions/Controls/FlagsCheckBox.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/BB84.WinForms.Extensions/Controls/FlagsRadioButton.Designer.cs
+++ b/src/BB84.WinForms.Extensions/Controls/FlagsRadioButton.Designer.cs
@@ -1,0 +1,61 @@
+﻿namespace BB84.WinForms.Extensions.Controls
+{
+    partial class FlagsRadioButton
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            flowLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
+            SuspendLayout();
+            // 
+            // flowLayoutPanel
+            // 
+            flowLayoutPanel.AutoScroll = true;
+            flowLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            flowLayoutPanel.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            flowLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            flowLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
+            flowLayoutPanel.Name = "flowLayoutPanel";
+            flowLayoutPanel.Size = new System.Drawing.Size(200, 150);
+            flowLayoutPanel.TabIndex = 0;
+            flowLayoutPanel.WrapContents = false;
+            // 
+            // UserControl1
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(flowLayoutPanel);
+            Name = "UserControl1";
+            Size = new System.Drawing.Size(200, 150);
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel;
+    }
+}

--- a/src/BB84.WinForms.Extensions/Controls/FlagsRadioButton.cs
+++ b/src/BB84.WinForms.Extensions/Controls/FlagsRadioButton.cs
@@ -1,0 +1,343 @@
+﻿using System.ComponentModel;
+using System.Globalization;
+
+namespace BB84.WinForms.Extensions.Controls;
+
+/// <summary>
+/// Represents a user control that displays a set of radio buttons for selecting multiple values
+/// of an enum type marked with the <see cref="FlagsAttribute"/>.
+/// </summary>
+/// <remarks>
+/// Use to bind to an enum type with the <see cref="FlagsAttribute"/>, allowing users to select
+/// one or more flags. The control requires the enum to define a zero-valued flag to represent no
+/// selection.
+/// </remarks>
+[DefaultBindingProperty(nameof(SelectedValue))]
+public partial class FlagsRadioButton : UserControl
+{
+	private Type? _enumType;
+	private Enum? _selectedValue;
+	private Enum? _zeroValue;
+	private bool _zeroValueDefined;
+	private bool _isUpdatingSelection;
+	private FlowDirection _flowDirection = FlowDirection.LeftToRight;
+	private Func<Enum, string>? _displayNameResolver;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="FlagsRadioButton"/> control.
+	/// </summary>
+	public FlagsRadioButton()
+	{
+		InitializeComponent();
+		ApplyFlowDirection();
+	}
+
+	/// <summary>
+	/// Gets or sets the layout direction used by the internal flow layout panel.
+	/// </summary>
+	[Category("Layout")]
+	[Description("Determines the layout direction used to arrange the radio buttons.")]
+	[DefaultValue(FlowDirection.LeftToRight)]
+	public FlowDirection FlowDirection
+	{
+		get => flowLayoutPanel?.FlowDirection ?? _flowDirection;
+		set
+		{
+			if (_flowDirection == value)
+				return;
+
+			_flowDirection = value;
+			ApplyFlowDirection();
+		}
+	}
+
+	/// <summary>
+	/// Gets or sets the delegate used to produce display names for each flag value.
+	/// </summary>
+	[Browsable(false)]
+	[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+	public Func<Enum, string>? DisplayNameResolver
+	{
+		get => _displayNameResolver;
+		set
+		{
+			if (_displayNameResolver == value)
+				return;
+
+			_displayNameResolver = value;
+			UpdateDisplayNames();
+		}
+	}
+
+	/// <summary>
+	/// Gets or sets the enum type that defines the flags to be displayed as check boxes.
+	/// </summary>
+	[Browsable(false)]
+	[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+	public Type? EnumType
+	{
+		get => _enumType;
+		set => SetEnumType(value);
+	}
+
+	/// <summary>
+	/// Gets or sets the currently selected value, which is a combination of the enum flags
+	/// represented by the check boxes.
+	/// </summary>
+	[Browsable(false)]
+	[Bindable(true)]
+	[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+	public Enum? SelectedValue
+	{
+		get => _selectedValue;
+		set
+		{
+			if (value is null)
+			{
+				SetSelectedValueToZero();
+				return;
+			}
+
+			if (_enumType is null)
+				EnumType = value.GetType();
+
+			if (value.GetType() != _enumType)
+				throw new ArgumentException($"Selected value must be of type {_enumType}.", nameof(value));
+
+			long numericValue = Convert.ToInt64(value, CultureInfo.InvariantCulture);
+
+			if (numericValue == 0 && !_zeroValueDefined)
+				throw new ArgumentException("Selected value cannot be zero because the enum does not define a zero-valued flag.", nameof(value));
+
+			Enum newValue = numericValue == 0 && _zeroValue is not null ? _zeroValue : value;
+
+			if (Equals(_selectedValue, newValue))
+				return;
+
+			_selectedValue = newValue;
+			UpdateRadioButtonsFromValue();
+			OnSelectedValueChanged(EventArgs.Empty);
+		}
+	}
+
+	/// <summary>
+	/// Occurs when the selected value changes.
+	/// </summary>
+	public event EventHandler? SelectedValueChanged;
+
+	/// <summary>
+	/// Is called when the selected value changes, either through user interaction or programmatically.
+	/// </summary>
+	/// <param name="e">The event data.</param>s
+	protected virtual void OnSelectedValueChanged(EventArgs e)
+		=> SelectedValueChanged?.Invoke(this, e);
+
+	private void SetEnumType(Type? value)
+	{
+		if (value == _enumType)
+			return;
+
+		_zeroValueDefined = false;
+		_zeroValue = null;
+
+		if (value is not null)
+		{
+			if (!value.IsEnum)
+				throw new ArgumentException("EnumType must be an enum type.", nameof(value));
+
+			if (!Attribute.IsDefined(value, typeof(FlagsAttribute)))
+				throw new ArgumentException("EnumType must be decorated with FlagsAttribute.", nameof(value));
+
+			foreach (Enum enumValue in Enum.GetValues(value))
+			{
+				if (Convert.ToInt64(enumValue, CultureInfo.InvariantCulture) == 0)
+				{
+					_zeroValueDefined = true;
+					_zeroValue = enumValue;
+					break;
+				}
+			}
+
+			if (!_zeroValueDefined)
+				throw new ArgumentException("EnumType must define a zero-valued flag to represent no selection.", nameof(value));
+		}
+
+		_enumType = value;
+		BuildRadioButtons();
+
+		if (_enumType is null)
+		{
+			if (_selectedValue is not null)
+			{
+				_selectedValue = null;
+				UpdateRadioButtonsFromValue();
+				OnSelectedValueChanged(EventArgs.Empty);
+			}
+			return;
+		}
+
+		if (_selectedValue is null || _selectedValue.GetType() != _enumType)
+		{
+			_selectedValue = _zeroValue;
+			UpdateRadioButtonsFromValue();
+			OnSelectedValueChanged(EventArgs.Empty);
+		}
+	}
+
+	private void BuildRadioButtons()
+	{
+		if (flowLayoutPanel is null)
+			return;
+
+		flowLayoutPanel.SuspendLayout();
+		try
+		{
+			foreach (Control control in flowLayoutPanel.Controls)
+				control.Dispose();
+
+			flowLayoutPanel.Controls.Clear();
+
+			if (_enumType is null)
+				return;
+
+			foreach (Enum flagValue in Enum.GetValues(_enumType))
+			{
+				if (Convert.ToInt64(flagValue, CultureInfo.InvariantCulture) == 0)
+					continue;
+
+				var radioButton = new RadioButton
+				{
+					AutoCheck = false,
+					AutoSize = true,
+					Text = ResolveDisplayName(flagValue),
+					Tag = flagValue,
+					Margin = new Padding(3),
+				};
+
+				radioButton.Click += HandleRadioButtonClick;
+				flowLayoutPanel.Controls.Add(radioButton);
+			}
+		}
+		finally
+		{
+			flowLayoutPanel.ResumeLayout();
+		}
+
+		UpdateRadioButtonsFromValue();
+		UpdateDisplayNames();
+	}
+
+	private void HandleRadioButtonClick(object? sender, EventArgs e)
+	{
+		if (_isUpdatingSelection)
+			return;
+
+		if (_enumType is null || sender is not RadioButton radioButton || radioButton.Tag is not Enum flagValue)
+			return;
+
+		long flagBits = Convert.ToInt64(flagValue, CultureInfo.InvariantCulture);
+
+		if (flagBits == 0)
+			return;
+
+		long currentBits = _selectedValue is not null
+			? Convert.ToInt64(_selectedValue, CultureInfo.InvariantCulture)
+			: 0;
+
+		long newBits = (currentBits & flagBits) == flagBits
+				? currentBits & ~flagBits
+				: currentBits | flagBits;
+
+		if (newBits == 0)
+		{
+			if (_zeroValue is not null)
+			{
+				SelectedValue = _zeroValue;
+			}
+			else
+			{
+				UpdateRadioButtonsFromValue();
+			}
+			return;
+		}
+
+		var newValue = (Enum)Enum.ToObject(_enumType, newBits);
+		SelectedValue = newValue;
+	}
+
+	private void SetSelectedValueToZero()
+	{
+		if (!_zeroValueDefined || _zeroValue is null)
+		{
+			if (_selectedValue is not null)
+			{
+				_selectedValue = null;
+				UpdateRadioButtonsFromValue();
+				OnSelectedValueChanged(EventArgs.Empty);
+			}
+			return;
+		}
+
+		if (Equals(_selectedValue, _zeroValue))
+			return;
+
+		_selectedValue = _zeroValue;
+		UpdateRadioButtonsFromValue();
+		OnSelectedValueChanged(EventArgs.Empty);
+	}
+
+	private void UpdateRadioButtonsFromValue()
+	{
+		if (flowLayoutPanel is null)
+			return;
+
+		_isUpdatingSelection = true;
+		try
+		{
+			foreach (Control control in flowLayoutPanel.Controls)
+			{
+				if (control is RadioButton radioButton && radioButton.Tag is Enum value)
+				{
+					radioButton.Checked = IsFlagSet(_selectedValue, value);
+				}
+			}
+		}
+		finally
+		{
+			_isUpdatingSelection = false;
+		}
+	}
+
+	private static bool IsFlagSet(Enum? currentValue, Enum flagValue)
+	{
+		if (currentValue is null)
+			return false;
+
+		long currentBits = Convert.ToInt64(currentValue, CultureInfo.InvariantCulture);
+		long flagBits = Convert.ToInt64(flagValue, CultureInfo.InvariantCulture);
+		return flagBits != 0 && (currentBits & flagBits) == flagBits;
+	}
+
+	private void ApplyFlowDirection()
+	{
+		if (flowLayoutPanel is null || flowLayoutPanel.FlowDirection == _flowDirection)
+			return;
+
+		flowLayoutPanel.FlowDirection = _flowDirection;
+	}
+
+	private string ResolveDisplayName(Enum value)
+		=> _displayNameResolver?.Invoke(value) ?? value.ToString();
+
+	private void UpdateDisplayNames()
+	{
+		if (flowLayoutPanel is null)
+			return;
+
+		foreach (Control control in flowLayoutPanel.Controls)
+		{
+			if (control is RadioButton radioButton && radioButton.Tag is Enum value)
+				radioButton.Text = ResolveDisplayName(value);
+		}
+	}
+}

--- a/src/BB84.WinForms.Extensions/Controls/FlagsRadioButton.resx
+++ b/src/BB84.WinForms.Extensions/Controls/FlagsRadioButton.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/BB84.WinForms.Extensions/FlagsCheckBoxExtensions.cs
+++ b/src/BB84.WinForms.Extensions/FlagsCheckBoxExtensions.cs
@@ -1,0 +1,90 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+using BB84.WinForms.Extensions.Controls;
+using BB84.WinForms.Extensions.Helpers;
+
+namespace BB84.WinForms.Extensions;
+
+/// <summary>
+/// Provides extension methods for binding and working with the <see cref="FlagsCheckBox"/> control.
+/// </summary>
+public static class FlagsCheckBoxExtensions
+{
+	/// <summary>
+	/// Sets the <see cref="FlagsCheckBox.DisplayNameResolver"/> of the specified <see cref="FlagsCheckBox"/>
+	/// to a resolver that retrieves display names from the <see cref="DescriptionAttribute"/> of enum values.
+	/// </summary>
+	/// <param name="checkBox">The <see cref="FlagsCheckBox"/> to configure.</param>
+	/// <returns>
+	/// The same <see cref="FlagsCheckBox"/> instance, so that additional configuration can be chained fluently.
+	/// </returns>
+	public static FlagsCheckBox WithDescriptionName(this FlagsCheckBox checkBox)
+	{
+		checkBox.WithDisplayNameResolver(FlagsDisplayResolvers.FromDescriptionAttribute);
+		return checkBox;
+	}
+
+	/// <summary>
+	/// Sets the <see cref="FlagsCheckBox.DisplayNameResolver"/> of the specified <see cref="FlagsCheckBox"/>
+	/// to a resolver that retrieves display names from the <see cref="DisplayAttribute"/> of enum values.
+	/// </summary>
+	/// <param name="checkBox">The <see cref="FlagsCheckBox"/> to configure.</param>
+	/// <returns>
+	/// The same <see cref="FlagsCheckBox"/> instance, so that additional configuration can be chained fluently.
+	/// </returns>
+	public static FlagsCheckBox WithDisplayName(this FlagsCheckBox checkBox)
+	{
+		checkBox.WithDisplayNameResolver(FlagsDisplayResolvers.FromDisplayAttribute);
+		return checkBox;
+	}
+
+	/// <summary>
+	/// Sets the <see cref="FlagsCheckBox.DisplayNameResolver"/> used to provide user-friendly captions.
+	/// </summary>
+	/// <param name="checkBox">The <see cref="FlagsCheckBox"/> to configure.</param>
+	/// <param name="resolver">The delegate that resolves a display name for each flag value.</param>
+	/// <returns>
+	/// The same <see cref="FlagsCheckBox"/> instance, so that additional configuration can be chained fluently.
+	/// </returns>
+	public static FlagsCheckBox WithDisplayNameResolver(this FlagsCheckBox checkBox, Func<Enum, string> resolver)
+	{
+		checkBox.DisplayNameResolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+		return checkBox;
+	}
+
+	/// <summary>
+	/// Sets the <see cref="FlagsCheckBox.FlowDirection"/> property of the specified <see cref="FlagsCheckBox"/>
+	/// to the given <see cref="FlowDirection"/> value.
+	/// </summary>
+	/// <param name="checkBox">The <see cref="FlagsCheckBox"/> to modify.</param>
+	/// <param name="direction">The <see cref="FlowDirection"/> value to set.</param>
+	/// <returns>
+	/// The same <see cref="FlagsCheckBox"/> instance, so that additional configuration can be chained fluently.
+	/// </returns>
+	public static FlagsCheckBox WithFlowDirection(this FlagsCheckBox checkBox, FlowDirection direction)
+	{
+		checkBox.FlowDirection = direction;
+		return checkBox;
+	}
+
+	/// <summary>
+	/// Binds the <see cref="FlagsCheckBox.SelectedValue"/> property of the specified <see cref="FlagsCheckBox"/>
+	/// to a property on the provided data source.
+	/// </summary>
+	/// <remarks>
+	/// The binding is configured to update the data source whenever the <see cref="FlagsCheckBox.SelectedValue"/> 
+	/// property changes, using <see cref="DataSourceUpdateMode.OnPropertyChanged"/>.
+	/// </remarks>
+	/// <param name="checkBox">The <see cref="FlagsCheckBox"/> to bind.</param>
+	/// <param name="dataSource">The data source containing the property to bind to.</param>
+	/// <param name="dataMember">The name of the property on the data source to bind to.</param>
+	/// <returns>
+	/// The <see cref="FlagsCheckBox"/> control with the binding applied, allowing for method chaining.
+	/// </returns>
+	public static FlagsCheckBox WithSelectedValueBinding(this FlagsCheckBox checkBox, object dataSource, string dataMember)
+	{
+		checkBox.DataBindings.Add(nameof(checkBox.SelectedValue), dataSource, dataMember, true, DataSourceUpdateMode.OnPropertyChanged);
+		return checkBox;
+	}
+}

--- a/src/BB84.WinForms.Extensions/FlagsRadioButtonExtensions.cs
+++ b/src/BB84.WinForms.Extensions/FlagsRadioButtonExtensions.cs
@@ -1,0 +1,89 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+using BB84.WinForms.Extensions.Controls;
+using BB84.WinForms.Extensions.Helpers;
+
+namespace BB84.WinForms.Extensions;
+
+/// <summary>
+/// Provides extension methods for binding and working with the <see cref="FlagsRadioButton"/> control.
+/// </summary>
+public static class FlagsRadioButtonExtensions
+{
+	/// <summary>
+	/// Sets the <see cref="FlagsRadioButton.DisplayNameResolver"/> of the specified <see cref="FlagsRadioButton"/>
+	/// to a resolver that retrieves display names from the <see cref="DescriptionAttribute"/> of enum values.
+	/// </summary>
+	/// <param name="radioButton">The <see cref="FlagsRadioButton"/> to configure.</param>
+	/// <returns>
+	/// The same <see cref="FlagsRadioButton"/> instance, so that additional configuration can be chained fluently.
+	/// </returns>
+	public static FlagsRadioButton WithDescriptionName(this FlagsRadioButton radioButton)
+	{
+		radioButton.WithDisplayNameResolver(FlagsDisplayResolvers.FromDescriptionAttribute);
+		return radioButton;
+	}
+
+	/// <summary>
+	/// Sets the <see cref="FlagsRadioButton.DisplayNameResolver"/> of the specified <see cref="FlagsRadioButton"/>
+	/// to a resolver that retrieves display names from the <see cref="DisplayAttribute"/> of enum values.
+	/// </summary>
+	/// <param name="radioButton">The <see cref="FlagsRadioButton"/> to configure.</param>
+	/// <returns>
+	/// The same <see cref="FlagsRadioButton"/> instance, so that additional configuration can be chained fluently.
+	/// </returns>
+	public static FlagsRadioButton WithDisplayName(this FlagsRadioButton radioButton)
+	{
+		radioButton.WithDisplayNameResolver(FlagsDisplayResolvers.FromDisplayAttribute);
+		return radioButton;
+	}
+
+	/// <summary>
+	/// Sets the <see cref="FlagsRadioButton.DisplayNameResolver"/> used to provide user-friendly captions.
+	/// </summary>
+	/// <param name="radioButton">The <see cref="FlagsRadioButton"/> to configure.</param>
+	/// <param name="resolver">The delegate that resolves a display name for each flag value.</param>
+	/// <returns>
+	/// The same <see cref="FlagsRadioButton"/> instance, so that additional configuration can be chained fluently.
+	/// </returns>
+	public static FlagsRadioButton WithDisplayNameResolver(this FlagsRadioButton radioButton, Func<Enum, string> resolver)
+	{
+		radioButton.DisplayNameResolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+		return radioButton;
+	}
+
+	/// <summary>
+	/// Sets the <see cref="FlagsRadioButton.FlowDirection"/> property of the specified <see cref="FlagsCheckBox"/> to the given <see cref="FlowDirection"/> value.
+	/// </summary>
+	/// <param name="radioButton">The <see cref="FlagsRadioButton"/> to modify.</param>
+	/// <param name="direction">The <see cref="FlowDirection"/> value to set.</param>
+	/// <returns>
+	/// The same <see cref="FlagsRadioButton"/> instance, so that additional configuration can be chained fluently.
+	/// </returns>
+	public static FlagsRadioButton WithFlowDirection(this FlagsRadioButton radioButton, FlowDirection direction)
+	{
+		radioButton.FlowDirection = direction;
+		return radioButton;
+	}
+
+	/// <summary>
+	/// Binds the <see cref="FlagsRadioButton.SelectedValue"/> property of the specified <see cref="FlagsRadioButton"/>
+	/// to a property on the provided data source.
+	/// </summary>
+	/// <remarks>
+	/// The binding is configured to update the data source whenever the <see cref="FlagsRadioButton.SelectedValue"/> 
+	/// property changes, using <see cref="DataSourceUpdateMode.OnPropertyChanged"/>.
+	/// </remarks>
+	/// <param name="radioButton">The <see cref="FlagsRadioButton"/> to bind.</param>
+	/// <param name="dataSource">The data source containing the property to bind to.</param>
+	/// <param name="dataMember">The name of the property on the data source to bind to.</param>
+	/// <returns>
+	/// The <see cref="FlagsRadioButton"/> control with the binding applied, allowing for method chaining.
+	/// </returns>
+	public static FlagsRadioButton WithSelectedValueBinding(this FlagsRadioButton radioButton, object dataSource, string dataMember)
+	{
+		radioButton.DataBindings.Add(nameof(radioButton.SelectedValue), dataSource, dataMember, true, DataSourceUpdateMode.OnPropertyChanged);
+		return radioButton;
+	}
+}

--- a/src/BB84.WinForms.Extensions/Helpers/FlagsDisplayResolvers.cs
+++ b/src/BB84.WinForms.Extensions/Helpers/FlagsDisplayResolvers.cs
@@ -1,0 +1,89 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace BB84.WinForms.Extensions.Helpers;
+
+/// <summary>
+/// Provides helpers that resolve friendly names for enum values used by the flags controls.
+/// </summary>
+/// <remarks>
+/// This class uses caching to improve performance when resolving display names for enum values.
+/// </remarks>
+public static class FlagsDisplayResolvers
+{
+	private static readonly ConcurrentDictionary<(Type EnumType, string Name), string?> DescriptionCache = new();
+	private static readonly ConcurrentDictionary<(Type EnumType, string Name), string?> DisplayCache = new();
+
+	/// <summary>
+	/// Resolves the display name of the supplied enum value using the <see cref="DescriptionAttribute"/>.
+	/// </summary>
+	/// <param name="value">The enum value whose description should be used.</param>
+	/// <returns>The description text if found; otherwise the enum member name.</returns>
+	public static string FromDescriptionAttribute(Enum value)
+	{
+		return value is not null
+			? GetDescription(value) ?? value.ToString() ?? string.Empty
+			: throw new ArgumentNullException(nameof(value));
+	}
+
+	/// <summary>
+	/// Resolves the display name of the supplied enum value using the <see cref="DisplayAttribute"/>.
+	/// </summary>
+	/// <param name="value">The enum value whose display attribute should be used.</param>
+	/// <returns>The attribute name if found; otherwise the enum member name.</returns>
+	public static string FromDisplayAttribute(Enum value)
+	{
+		return value is not null
+			? GetDisplayName(value) ?? value.ToString() ?? string.Empty
+			: throw new ArgumentNullException(nameof(value));
+	}
+
+	private static string? GetDescription(Enum value)
+	{
+		(ConcurrentDictionary<(Type EnumType, string Name), string?> cache, (Type EnumType, string Name) key) setup;
+
+		return !TryCreateKey(value, DescriptionCache, out setup)
+			? null
+			: setup.cache.GetOrAdd(setup.key,
+			static staticKey => ResolveDescription(staticKey.EnumType, staticKey.Name));
+	}
+
+	private static string? GetDisplayName(Enum value)
+	{
+		(ConcurrentDictionary<(Type EnumType, string Name), string?> cache, (Type EnumType, string Name) key) setup;
+		return !TryCreateKey(value, DisplayCache, out setup)
+			? null
+			: setup.cache.GetOrAdd(setup.key,
+			static staticKey => ResolveDisplay(staticKey.EnumType, staticKey.Name));
+	}
+
+	private static bool TryCreateKey(Enum value, ConcurrentDictionary<(Type EnumType, string Name), string?> cache, out (ConcurrentDictionary<(Type EnumType, string Name), string?> cache, (Type EnumType, string Name) key) setup)
+	{
+		Type enumType = value.GetType();
+		string? name = Enum.GetName(enumType, value);
+		if (name is null)
+		{
+			setup = default;
+			return false;
+		}
+
+		setup = (cache, (enumType, name));
+		return true;
+	}
+
+	private static string? ResolveDescription(Type enumType, string name)
+	{
+		FieldInfo? field = enumType.GetField(name, BindingFlags.Public | BindingFlags.Static);
+		DescriptionAttribute? attribute = field?.GetCustomAttribute<DescriptionAttribute>();
+		return attribute?.Description;
+	}
+
+	private static string? ResolveDisplay(Type enumType, string name)
+	{
+		FieldInfo? field = enumType.GetField(name, BindingFlags.Public | BindingFlags.Static);
+		DisplayAttribute? attribute = field?.GetCustomAttribute<DisplayAttribute>();
+		return attribute?.GetName() ?? attribute?.Name;
+	}
+}

--- a/tests/BB84.WinForms.Extensions.Tests/FlagsCheckBoxExtensionsTests.cs
+++ b/tests/BB84.WinForms.Extensions.Tests/FlagsCheckBoxExtensionsTests.cs
@@ -1,0 +1,81 @@
+﻿using BB84.WinForms.Extensions.Controls;
+using BB84.WinForms.Extensions.Helpers;
+
+namespace BB84.WinForms.Extensions.Tests;
+
+[TestClass]
+public sealed class FlagsCheckBoxExtensionsTests
+{
+	[TestMethod]
+	public void WithDescriptionNameTest()
+	{
+		FlagsCheckBox checkBox = new();
+
+		checkBox.WithDescriptionName();
+
+		Assert.AreEqual(FlagsDisplayResolvers.FromDescriptionAttribute, checkBox.DisplayNameResolver);
+	}
+
+	[TestMethod]
+	public void WithDisplayNameTest()
+	{
+		FlagsCheckBox checkBox = new();
+
+		checkBox.WithDisplayName();
+
+		Assert.AreEqual(FlagsDisplayResolvers.FromDisplayAttribute, checkBox.DisplayNameResolver);
+	}
+
+	[TestMethod]
+	public void WithDisplayNameResolverTest()
+	{
+		static string Resolver(Enum e) => $"Flag: {e}";
+		FlagsCheckBox checkBox = new();
+
+		checkBox.WithDisplayNameResolver(Resolver);
+
+		Assert.AreEqual(Resolver, checkBox.DisplayNameResolver);
+	}
+
+	[TestMethod]
+	public void WithDisplayNameResolverNullResolverThrowsArgumentNullException()
+	{
+		FlagsCheckBox checkBox = new();
+
+		Assert.Throws<ArgumentNullException>(() => checkBox.WithDisplayNameResolver(null!));
+	}
+
+	[TestMethod]
+	public void WithFlowDirectionTest()
+	{
+		FlagsCheckBox checkBox = new();
+
+		checkBox.WithFlowDirection(FlowDirection.RightToLeft);
+
+		Assert.AreEqual(FlowDirection.RightToLeft, checkBox.FlowDirection);
+	}
+
+	[TestMethod]
+	public void WithSelectedValueBindingTest()
+	{
+		var datasource = new { SelectedFlag = TestEnumerator.None };
+
+		FlagsCheckBox checkBox = new FlagsCheckBox() { SelectedValue = TestEnumerator.FirstFlag }
+			.WithSelectedValueBinding(datasource, nameof(datasource.SelectedFlag));
+
+		Assert.IsNotNull(checkBox);
+		Assert.AreEqual(TestEnumerator.FirstFlag, checkBox.SelectedValue);
+	}
+
+	[Flags]
+	private enum TestEnumerator
+	{
+		None = 0,
+		[System.ComponentModel.DataAnnotations.Display(Name = "First Flag")]
+		FirstFlag = 1,
+		[System.ComponentModel.DataAnnotations.Display(Name = "Second Flag")]
+		SecondFlag = 2,
+		[System.ComponentModel.DataAnnotations.Display(Name = "Third Flag")]
+		ThirdFlag = 4
+	}
+}

--- a/tests/BB84.WinForms.Extensions.Tests/FlagsRadioButtonExtensionsTests.cs
+++ b/tests/BB84.WinForms.Extensions.Tests/FlagsRadioButtonExtensionsTests.cs
@@ -1,0 +1,81 @@
+﻿using BB84.WinForms.Extensions.Controls;
+using BB84.WinForms.Extensions.Helpers;
+
+namespace BB84.WinForms.Extensions.Tests;
+
+[TestClass]
+public sealed class FlagsRadioButtonExtensionsTests
+{
+	[TestMethod]
+	public void WithDescriptionNameTest()
+	{
+		FlagsRadioButton radioButton = new();
+
+		radioButton.WithDescriptionName();
+
+		Assert.AreEqual(FlagsDisplayResolvers.FromDescriptionAttribute, radioButton.DisplayNameResolver);
+	}
+
+	[TestMethod]
+	public void WithDisplayNameTest()
+	{
+		FlagsRadioButton radioButton = new();
+
+		radioButton.WithDisplayName();
+
+		Assert.AreEqual(FlagsDisplayResolvers.FromDisplayAttribute, radioButton.DisplayNameResolver);
+	}
+
+	[TestMethod]
+	public void WithDisplayNameResolverTest()
+	{
+		static string Resolver(Enum e) => $"Flag: {e}";
+		FlagsRadioButton radioButton = new();
+
+		radioButton.WithDisplayNameResolver(Resolver);
+
+		Assert.AreEqual(Resolver, radioButton.DisplayNameResolver);
+	}
+
+	[TestMethod]
+	public void WithDisplayNameResolverNullResolverThrowsArgumentNullException()
+	{
+		FlagsRadioButton radioButton = new();
+
+		Assert.Throws<ArgumentNullException>(() => radioButton.WithDisplayNameResolver(null!));
+	}
+
+	[TestMethod]
+	public void WithFlowDirectionTest()
+	{
+		FlagsRadioButton radioButton = new();
+
+		radioButton.WithFlowDirection(FlowDirection.RightToLeft);
+
+		Assert.AreEqual(FlowDirection.RightToLeft, radioButton.FlowDirection);
+	}
+
+	[TestMethod]
+	public void WithSelectedValueBindingTest()
+	{
+		var datasource = new { SelectedFlag = TestEnumerator.FirstFlag };
+
+		FlagsRadioButton radioButton = new FlagsRadioButton() { SelectedValue = TestEnumerator.FirstFlag }
+			.WithSelectedValueBinding(datasource, nameof(datasource.SelectedFlag));
+
+		Assert.IsNotNull(radioButton);
+		Assert.AreEqual(TestEnumerator.FirstFlag, radioButton.SelectedValue);
+	}
+
+	[Flags]
+	private enum TestEnumerator
+	{
+		None = 0,
+		[System.ComponentModel.Description("First Flag")]
+		FirstFlag = 1,
+		[System.ComponentModel.Description("Second Flag")]
+		SecondFlag = 2,
+		[System.ComponentModel.Description("Third Flag")]
+		ThirdFlag = 4
+	}
+}


### PR DESCRIPTION
**Introduce reusable WinForms controls for selecting [Flags] enums:**

- Add `FlagsCheckBox` and `FlagsRadioButton` user controls with designer and resource files.
- Support data binding, flow direction, and customizable display names via `DescriptionAttribute` or `DisplayAttribute`.
- Provide extension methods for fluent configuration and binding.
- Add `FlagsDisplayResolvers` helper for efficient display name resolution.
- Reference `System.ComponentModel.Annotations` for `DisplayAttribute` support.
- Added unit tests to improve code coverage and maintainability.

closes #247 