### PR TITLE
refactor(extensions): add `TakeRandomOrDefault`/`TryTakeRandom` methods and tests

### DIFF
--- a/src/BB84.Extensions/ArrayExtensions.cs
+++ b/src/BB84.Extensions/ArrayExtensions.cs
@@ -3,8 +3,6 @@
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
-using BB84.Extensions.Helper;
-
 namespace BB84.Extensions;
 
 /// <summary>
@@ -40,4 +38,33 @@ public static class ArrayExtensions
 	/// </returns>
 	public static T TakeRandom<T>(this T[] array)
 		=> array.ToList().TakeRandom();
+
+	/// <summary>
+	/// Returns a random element from the specified <paramref name="array"/>, or the default value of
+	/// <typeparamref name="T"/> if the array is empty.
+	/// </summary>
+	/// <typeparam name="T">The type of elements in the array.</typeparam>
+	/// <param name="array">The array from which to select a random element.</param>
+	/// <returns>
+	/// A randomly selected element from <paramref name="array"/>, or <see langword="default"/> if
+	/// the array is empty.
+	/// </returns>
+	public static T? TakeRandomOrDefault<T>(this T[] array)
+		=> array.ToList().TakeRandomOrDefault();
+
+	/// <summary>
+	/// Attempts to retrieve a random element from the specified <paramref name="array"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of elements in the array.</typeparam>
+	/// <param name="array">The array from which to select a random element.</param>
+	/// <param name="result">
+	/// When this method returns <see langword="true"/>, contains a randomly selected element from
+	/// <paramref name="array"/>; otherwise, the default value of <typeparamref name="T"/>.
+	/// </param>
+	/// <returns>
+	/// <see langword="true"/> if <paramref name="array"/> is not empty and a random element was
+	/// selected; otherwise, <see langword="false"/>.
+	/// </returns>
+	public static bool TryTakeRandom<T>(this T[] array, [MaybeNullWhen(false)] out T result)
+		=> array.ToList().TryTakeRandom(out result);
 }

--- a/src/BB84.Extensions/EnumerableExtensions.cs
+++ b/src/BB84.Extensions/EnumerableExtensions.cs
@@ -136,4 +136,32 @@ public static class EnumerableExtensions
 	/// <returns>A random item from the collection.</returns>
 	public static T TakeRandom<T>(this IEnumerable<T> values)
 		=> values.ToArray().TakeRandom();
+
+	/// <summary>
+	/// Returns a randomly chosen item from the collection of <paramref name="values"/>, or the
+	/// default value of <typeparamref name="T"/> if the collection is empty.
+	/// </summary>
+	/// <typeparam name="T">The type of object in the collection.</typeparam>
+	/// <param name="values">The collection of objects to choose from.</param>
+	/// <returns>
+	/// A random item from the collection, or <see langword="default"/> if the collection is empty.
+	/// </returns>
+	public static T? TakeRandomOrDefault<T>(this IEnumerable<T> values)
+		=> values.ToArray().TakeRandomOrDefault();
+
+	/// <summary>
+	/// Attempts to retrieve a randomly chosen item from the collection of <paramref name="values"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of object in the collection.</typeparam>
+	/// <param name="values">The collection of objects to choose from.</param>
+	/// <param name="result">
+	/// When this method returns <see langword="true"/>, contains a randomly selected element from
+	/// <paramref name="values"/>; otherwise, the default value of <typeparamref name="T"/>.
+	/// </param>
+	/// <returns>
+	/// <see langword="true"/> if <paramref name="values"/> is not empty and a random element was
+	/// selected; otherwise, <see langword="false"/>.
+	/// </returns>
+	public static bool TryTakeRandom<T>(this IEnumerable<T> values, [MaybeNullWhen(false)] out T result)
+		=> values.ToArray().TryTakeRandom(out result);
 }

--- a/src/BB84.Extensions/ListExtensions.cs
+++ b/src/BB84.Extensions/ListExtensions.cs
@@ -94,4 +94,41 @@ public static class ListExtensions
 	/// <returns>A random element from the <paramref name="list"/>.</returns>
 	public static T TakeRandom<T>(this IList<T> list)
 		=> list[RandomHelper.Random.Next(0, list.Count)];
+
+	/// <summary>
+	/// Returns a random element from the specified list, or the default value of
+	/// <typeparamref name="T"/> if the list is empty.
+	/// </summary>
+	/// <typeparam name="T">The type of elements in the list.</typeparam>
+	/// <param name="list">The list from which to take a random element.</param>
+	/// <returns>
+	/// A random element from <paramref name="list"/>, or <see langword="default"/> if the list is empty.
+	/// </returns>
+	public static T? TakeRandomOrDefault<T>(this IList<T> list)
+		=> list.Count == 0 ? default : list.TakeRandom();
+
+	/// <summary>
+	/// Attempts to retrieve a random element from the specified list.
+	/// </summary>
+	/// <typeparam name="T">The type of elements in the list.</typeparam>
+	/// <param name="list">The list from which to take a random element.</param>
+	/// <param name="result">
+	/// When this method returns <see langword="true"/>, contains a randomly selected element from
+	/// <paramref name="list"/>; otherwise, the default value of <typeparamref name="T"/>.
+	/// </param>
+	/// <returns>
+	/// <see langword="true"/> if <paramref name="list"/> is not empty and a random element was
+	/// selected; otherwise, <see langword="false"/>.
+	/// </returns>
+	public static bool TryTakeRandom<T>(this IList<T> list, [MaybeNullWhen(false)] out T result)
+	{
+		if (list.Count == 0)
+		{
+			result = default;
+			return false;
+		}
+
+		result = list.TakeRandom();
+		return true;
+	}
 }

--- a/tests/BB84.Extensions.Tests/ArrayExtensionsTests.TakeRandom.cs
+++ b/tests/BB84.Extensions.Tests/ArrayExtensionsTests.TakeRandom.cs
@@ -8,12 +8,56 @@ namespace BB84.Extensions.Tests;
 public sealed partial class ArrayExtensionsTests
 {
 	[TestMethod]
-	public void TakeRandom()
+	public void TakeRandomShouldReturnElementFromArray()
 	{
-		int[] ints = [1, 2, 3];
+		int[] ints = [1, 2, 3, 4, 5];
 
-		int i = ints.TakeRandom();
+		int result = ints.TakeRandom();
 
-		Assert.IsTrue(ints.Contains(i));
+		Assert.Contains(result, ints);
+	}
+
+	[TestMethod]
+	public void TakeRandomOrDefaultWithNonEmptyArrayShouldReturnElement()
+	{
+		int[] ints = [1, 2, 3, 4, 5];
+
+		int? result = ints.TakeRandomOrDefault();
+
+		Assert.IsNotNull(result);
+		Assert.Contains(result.Value, ints);
+	}
+
+	[TestMethod]
+	public void TakeRandomOrDefaultWithEmptyArrayShouldReturnDefault()
+	{
+		int[] ints = [];
+
+		int result = ints.TakeRandomOrDefault();
+
+		Assert.AreEqual(default, result);
+	}
+
+	[TestMethod]
+	public void TryTakeRandomWithNonEmptyArrayShouldReturnTrueAndElement()
+	{
+		int[] ints = [1, 2, 3, 4, 5];
+
+		bool success = ints.TryTakeRandom(out int result);
+
+		Assert.IsTrue(success);
+		Assert.Contains(result, ints);
+	}
+
+	[TestMethod]
+	public void TryTakeRandomWithEmptyArrayShouldReturnFalseAndDefault()
+	{
+		int[] ints = [];
+
+		bool success = ints.TryTakeRandom(out int result);
+
+		Assert.IsFalse(success);
+		Assert.AreEqual(default, result);
 	}
 }
+

--- a/tests/BB84.Extensions.Tests/EnumerableExtensionsTests.TakeRandom.cs
+++ b/tests/BB84.Extensions.Tests/EnumerableExtensionsTests.TakeRandom.cs
@@ -8,12 +8,56 @@ namespace BB84.Extensions.Tests;
 public sealed partial class EnumerableExtensionsTests
 {
 	[TestMethod]
-	public void TakeRandom()
+	public void TakeRandomShouldReturnElementFromSequence()
 	{
 		IEnumerable<int> ints = [1, 2, 3, 4, 5];
 
-		int i = ints.TakeRandom();
+		int result = ints.TakeRandom();
 
-		Assert.IsTrue(ints.Contains(i));
+		Assert.Contains(result, ints);
+	}
+
+	[TestMethod]
+	public void TakeRandomOrDefaultWithNonEmptySequenceShouldReturnElement()
+	{
+		IEnumerable<int> ints = [1, 2, 3, 4, 5];
+
+		int? result = ints.TakeRandomOrDefault();
+
+		Assert.IsNotNull(result);
+		Assert.Contains(result.Value, ints);
+	}
+
+	[TestMethod]
+	public void TakeRandomOrDefaultWithEmptySequenceShouldReturnDefault()
+	{
+		IEnumerable<int> ints = [];
+
+		int result = ints.TakeRandomOrDefault();
+
+		Assert.AreEqual(default, result);
+	}
+
+	[TestMethod]
+	public void TryTakeRandomWithNonEmptySequenceShouldReturnTrueAndElement()
+	{
+		IEnumerable<int> ints = [1, 2, 3, 4, 5];
+
+		bool success = ints.TryTakeRandom(out int result);
+
+		Assert.IsTrue(success);
+		Assert.Contains(result, ints);
+	}
+
+	[TestMethod]
+	public void TryTakeRandomWithEmptySequenceShouldReturnFalseAndDefault()
+	{
+		IEnumerable<int> ints = [];
+
+		bool success = ints.TryTakeRandom(out int result);
+
+		Assert.IsFalse(success);
+		Assert.AreEqual(default, result);
 	}
 }
+

--- a/tests/BB84.Extensions.Tests/EnumeratorExtensionsTests.GetValues.cs
+++ b/tests/BB84.Extensions.Tests/EnumeratorExtensionsTests.GetValues.cs
@@ -16,6 +16,6 @@ public sealed partial class EnumeratorExtensionsTests
 
 		IEnumerable<TestType> list = type.GetValues();
 
-		Assert.AreEqual(3, list.Count());
+		Assert.HasCount(3, list);
 	}
 }

--- a/tests/BB84.Extensions.Tests/HttpRequestMessageExtensionsTests.cs
+++ b/tests/BB84.Extensions.Tests/HttpRequestMessageExtensionsTests.cs
@@ -31,6 +31,6 @@ public sealed class HttpRequestMessageExtensionsTests
 
 		httpRequestMessage.WithMediaType(mediaType);
 
-		Assert.IsTrue(httpRequestMessage.Headers.Accept.Any(h => h.MediaType == mediaType));
+		Assert.Contains(h => h.MediaType == mediaType, httpRequestMessage.Headers.Accept);
 	}
 }

--- a/tests/BB84.Extensions.Tests/ListExtensionsTests.TakeRandom.cs
+++ b/tests/BB84.Extensions.Tests/ListExtensionsTests.TakeRandom.cs
@@ -1,0 +1,62 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.Extensions.Tests;
+
+public sealed partial class ListExtensionsTests
+{
+	[TestMethod]
+	public void TakeRandomShouldReturnElementFromList()
+	{
+		IList<int> list = [1, 2, 3, 4, 5];
+
+		int result = list.TakeRandom();
+
+		Assert.Contains(result, list);
+	}
+
+	[TestMethod]
+	public void TakeRandomOrDefaultWithNonEmptyListShouldReturnElement()
+	{
+		IList<int> list = [1, 2, 3, 4, 5];
+
+		int? result = list.TakeRandomOrDefault();
+
+		Assert.IsNotNull(result);
+		Assert.Contains(result.Value, list);
+	}
+
+	[TestMethod]
+	public void TakeRandomOrDefaultWithEmptyListShouldReturnDefault()
+	{
+		IList<int> list = [];
+
+		int result = list.TakeRandomOrDefault();
+
+		Assert.AreEqual(default, result);
+	}
+
+	[TestMethod]
+	public void TryTakeRandomWithNonEmptyListShouldReturnTrueAndElement()
+	{
+		IList<int> list = [1, 2, 3, 4, 5];
+
+		bool success = list.TryTakeRandom(out int result);
+
+		Assert.IsTrue(success);
+		Assert.Contains(result, list);
+	}
+
+	[TestMethod]
+	public void TryTakeRandomWithEmptyListShouldReturnFalseAndDefault()
+	{
+		IList<int> list = [];
+
+		bool success = list.TryTakeRandom(out int result);
+
+		Assert.IsFalse(success);
+		Assert.AreEqual(default, result);
+	}
+}


### PR DESCRIPTION
**Changes:**

- Added `TakeRandomOrDefault` and `TryTakeRandom` extension methods for arrays, lists, and `IEnumerable<T>` to safely retrieve a random element or default if empty.
- Updated XML docs, improved test assertions, and added comprehensive unit tests for these methods.

closes #271 