### PR TITLE
refactor(extensions): Improve validation and tests for HTTP client extensions

### DIFF
--- a/src/BB84.Extensions/HttpClientExtensions.cs
+++ b/src/BB84.Extensions/HttpClientExtensions.cs
@@ -29,10 +29,33 @@ public static class HttpClientExtensions
 	/// <param name="client">The http client which should use the base address.</param>
 	/// <param name="baseAddress">The base address to be used.</param>
 	/// <returns>The same <see cref="HttpClient"/> instance so that multiple calls can be chained.</returns>
+	/// <exception cref="ArgumentNullException">If <paramref name="baseAddress"/> is <see langword="null"/>.</exception>
+	/// <exception cref="ArgumentException">If <paramref name="baseAddress"/> is empty, whitespace, or not a valid absolute URI.</exception>
 	public static HttpClient WithBaseAddress(this HttpClient client, string baseAddress)
+		=> client.WithBaseAddress(baseAddress, UriKind.Absolute);
+
+	/// <summary>
+	/// Adds the specified <paramref name="baseAddress"/> to the http client configuration.
+	/// </summary>
+	/// <param name="client">The http client which should use the base address.</param>
+	/// <param name="baseAddress">The base address to be used.</param>
+	/// <param name="uriKind">Specifies whether the URI string is relative, absolute, or indeterminate.</param>
+	/// <returns>The same <see cref="HttpClient"/> instance so that multiple calls can be chained.</returns>
+	/// <exception cref="ArgumentNullException">If <paramref name="baseAddress"/> is <see langword="null"/>.</exception>
+	/// <exception cref="ArgumentException">If <paramref name="baseAddress"/> is empty, whitespace, or not a valid URI for the given <paramref name="uriKind"/>.</exception>
+	public static HttpClient WithBaseAddress(this HttpClient client, string baseAddress, UriKind uriKind)
 	{
-		client.WithBaseAddress(new Uri(baseAddress));
-		return client;
+#if NET6_0_OR_GREATER
+		ArgumentNullException.ThrowIfNull(baseAddress);
+#else
+		if (baseAddress is null)
+			throw new ArgumentNullException(nameof(baseAddress));
+#endif
+		if (string.IsNullOrWhiteSpace(baseAddress))
+			throw new ArgumentException("The base address must not be empty or whitespace.", nameof(baseAddress));
+		if (!Uri.TryCreate(baseAddress, uriKind, out Uri? uri))
+			throw new ArgumentException($"'{baseAddress}' is not a valid URI.", nameof(baseAddress));
+		return client.WithBaseAddress(uri);
 	}
 
 	/// <summary>
@@ -57,6 +80,17 @@ public static class HttpClientExtensions
 	/// <returns>The same <see cref="HttpClient"/> instance so that multiple calls can be chained.</returns>
 	public static HttpClient WithBasicAuthentication(this HttpClient client, string username, string password, Encoding? encoding = null)
 	{
+#if NET6_0_OR_GREATER
+		ArgumentNullException.ThrowIfNull(username);
+		ArgumentNullException.ThrowIfNull(password);
+#else
+		if (username is null)
+			throw new ArgumentNullException(nameof(username));
+		if (password is null)
+			throw new ArgumentNullException(nameof(password));
+#endif
+		if (string.IsNullOrWhiteSpace(username))
+			throw new ArgumentException("The username must not be empty or whitespace.", nameof(username));
 		encoding ??= Encoding.ASCII;
 		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(Constants.HttpHeaders.BasicScheme, Convert.ToBase64String(encoding.GetBytes($"{username}:{password}")));
 		return client;
@@ -70,6 +104,14 @@ public static class HttpClientExtensions
 	/// <returns>The same <see cref="HttpClient"/> instance so that multiple calls can be chained.</returns>
 	public static HttpClient WithBearerToken(this HttpClient client, string token)
 	{
+#if NET6_0_OR_GREATER
+		ArgumentNullException.ThrowIfNull(token);
+#else
+		if (token is null)
+			throw new ArgumentNullException(nameof(token));
+#endif
+		if (string.IsNullOrEmpty(token))
+			throw new ArgumentException("The token must not be empty.", nameof(token));
 		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(Constants.HttpHeaders.BearerScheme, token);
 		return client;
 	}
@@ -82,7 +124,8 @@ public static class HttpClientExtensions
 	/// <returns>The same <see cref="HttpClient"/> instance so that multiple calls can be chained.</returns>
 	public static HttpClient WithMediaType(this HttpClient client, string mediaType)
 	{
-		client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(mediaType));
+		if (!client.DefaultRequestHeaders.Accept.Any(h => h.MediaType == mediaType))
+			client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(mediaType));
 		return client;
 	}
 

--- a/src/BB84.Extensions/HttpRequestMessageExtensions.cs
+++ b/src/BB84.Extensions/HttpRequestMessageExtensions.cs
@@ -31,6 +31,14 @@ public static class HttpRequestMessageExtensions
 	/// <returns>The same <see cref="HttpRequestMessage"/> instance, allowing for method chaining.</returns>
 	public static HttpRequestMessage WithBearerToken(this HttpRequestMessage httpRequestMessage, string token)
 	{
+#if NET6_0_OR_GREATER
+		ArgumentNullException.ThrowIfNull(token);
+#else
+		if (token is null)
+			throw new ArgumentNullException(nameof(token));
+#endif
+		if (string.IsNullOrEmpty(token))
+			throw new ArgumentException("The token must not be empty.", nameof(token));
 		httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue(Constants.HttpHeaders.BearerScheme, token);
 		return httpRequestMessage;
 	}
@@ -48,7 +56,8 @@ public static class HttpRequestMessageExtensions
 	/// <returns>The same <see cref="HttpRequestMessage"/> instance, allowing for method chaining.</returns>
 	public static HttpRequestMessage WithMediaType(this HttpRequestMessage httpRequestMessage, string mediaType)
 	{
-		httpRequestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(mediaType));
+		if (!httpRequestMessage.Headers.Accept.Any(h => h.MediaType == mediaType))
+			httpRequestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(mediaType));
 		return httpRequestMessage;
 	}
 }

--- a/tests/BB84.Extensions.Tests/HttpClientExtensionsTests.cs
+++ b/tests/BB84.Extensions.Tests/HttpClientExtensionsTests.cs
@@ -13,7 +13,7 @@ public sealed class HttpClientExtensionsTests
 {
 	[TestMethod]
 	[DataRow("https://example.com")]
-	public void WithBaseAddressTest(string baseAddress)
+	public void WithBaseAddressShouldSetBaseAddress(string baseAddress)
 	{
 		using HttpClient client = new HttpClient()
 			.WithBaseAddress(baseAddress);
@@ -22,19 +22,57 @@ public sealed class HttpClientExtensionsTests
 	}
 
 	[TestMethod]
+	[DataRow("https://example.com")]
+	public void WithBaseAddressWithUriKindShouldSetBaseAddress(string baseAddress)
+	{
+		using HttpClient client = new HttpClient()
+			.WithBaseAddress(baseAddress, UriKind.Absolute);
+
+		Assert.AreEqual($"{baseAddress}/", client.BaseAddress!.ToString());
+	}
+
+	[TestMethod]
+	[DataRow(null)]
+	public void WithBaseAddressWithNullShouldThrowArgumentNullException(string? baseAddress)
+	{
+		using HttpClient client = new();
+
+		Assert.Throws<ArgumentNullException>(() => client.WithBaseAddress(baseAddress!));
+	}
+
+	[TestMethod]
+	[DataRow("")]
+	[DataRow("   ")]
+	public void WithBaseAddressWithEmptyOrWhitespaceShouldThrowArgumentException(string baseAddress)
+	{
+		using HttpClient client = new();
+
+		Assert.Throws<ArgumentException>(() => client.WithBaseAddress(baseAddress));
+	}
+
+	[TestMethod]
+	[DataRow("not a uri")]
+	public void WithBaseAddressWithInvalidUriShouldThrowArgumentException(string baseAddress)
+	{
+		using HttpClient client = new();
+
+		Assert.Throws<ArgumentException>(() => client.WithBaseAddress(baseAddress));
+	}
+
+	[TestMethod]
 	[DataRow("FancyUserName", "FancyPassword")]
-	public void WithBasicAuthenticationTest(string username, string password)
+	public void WithBasicAuthenticationShouldSetAuthorizationHeader(string username, string password)
 	{
 		using HttpClient client = new HttpClient()
 			.WithBasicAuthentication(username, password);
-		
+
 		Assert.AreEqual("Basic", client.DefaultRequestHeaders.Authorization!.Scheme);
 		Assert.AreEqual(Convert.ToBase64String(Encoding.ASCII.GetBytes($"{username}:{password}")), client.DefaultRequestHeaders.Authorization.Parameter);
 	}
 
 	[TestMethod]
 	[DataRow("FancyUserName", "FancyPassword")]
-	public void WithBasicAuthenticationWithEncodingTest(string username, string password)
+	public void WithBasicAuthenticationWithEncodingShouldSetAuthorizationHeader(string username, string password)
 	{
 		using HttpClient client = new HttpClient()
 			.WithBasicAuthentication(username, password, Encoding.UTF8);
@@ -44,9 +82,36 @@ public sealed class HttpClientExtensionsTests
 	}
 
 	[TestMethod]
+	[DataRow(null, "password")]
+	public void WithBasicAuthenticationWithNullUsernameShouldThrowArgumentNullException(string? username, string password)
+	{
+		using HttpClient client = new();
+
+		Assert.Throws<ArgumentNullException>(() => client.WithBasicAuthentication(username!, password));
+	}
+
+	[TestMethod]
+	[DataRow("", "password")]
+	[DataRow("   ", "password")]
+	public void WithBasicAuthenticationWithEmptyOrWhitespaceUsernameShouldThrowArgumentException(string username, string password)
+	{
+		using HttpClient client = new();
+
+		Assert.Throws<ArgumentException>(() => client.WithBasicAuthentication(username, password));
+	}
+
+	[TestMethod]
+	[DataRow("username", null)]
+	public void WithBasicAuthenticationWithNullPasswordShouldThrowArgumentNullException(string username, string? password)
+	{
+		using HttpClient client = new();
+
+		Assert.Throws<ArgumentNullException>(() => client.WithBasicAuthentication(username, password!));
+	}
+
+	[TestMethod]
 	[DataRow("FancyToken")]
-	[DataRow("")]
-	public void WithBearerTokenTest(string token)
+	public void WithBearerTokenShouldSetAuthorizationHeader(string token)
 	{
 		using HttpClient client = new HttpClient()
 			.WithBearerToken(token);
@@ -55,9 +120,27 @@ public sealed class HttpClientExtensionsTests
 	}
 
 	[TestMethod]
+	[DataRow(null)]
+	public void WithBearerTokenWithNullShouldThrowArgumentNullException(string? token)
+	{
+		using HttpClient client = new();
+
+		Assert.Throws<ArgumentNullException>(() => client.WithBearerToken(token!));
+	}
+
+	[TestMethod]
+	[DataRow("")]
+	public void WithBearerTokenWithEmptyShouldThrowArgumentException(string token)
+	{
+		using HttpClient client = new();
+
+		Assert.Throws<ArgumentException>(() => client.WithBearerToken(token));
+	}
+
+	[TestMethod]
 	[DataRow("application/json")]
 	[DataRow("text/plain")]
-	public void WithMediaTypeTest(string mediaType)
+	public void WithMediaTypeShouldAddMediaTypeToAcceptHeader(string mediaType)
 	{
 		using HttpClient client = new HttpClient()
 			.WithMediaType(mediaType);
@@ -66,7 +149,18 @@ public sealed class HttpClientExtensionsTests
 	}
 
 	[TestMethod]
-	public void WithTimeout()
+	[DataRow("application/json")]
+	public void WithMediaTypeCalledTwiceShouldNotDuplicateEntry(string mediaType)
+	{
+		using HttpClient client = new HttpClient()
+			.WithMediaType(mediaType)
+			.WithMediaType(mediaType);
+
+		Assert.HasCount(1, client.DefaultRequestHeaders.Accept);
+	}
+
+	[TestMethod]
+	public void WithTimeoutShouldSetTimeout()
 	{
 		TimeSpan timeout = new(0, 0, 15);
 
@@ -76,3 +170,4 @@ public sealed class HttpClientExtensionsTests
 		Assert.AreEqual(timeout, client.Timeout);
 	}
 }
+

--- a/tests/BB84.Extensions.Tests/HttpRequestMessageExtensionsTests.cs
+++ b/tests/BB84.Extensions.Tests/HttpRequestMessageExtensionsTests.cs
@@ -11,7 +11,7 @@ namespace BB84.Extensions.Tests;
 public sealed class HttpRequestMessageExtensionsTests
 {
 	[TestMethod]
-	public void WithBearerTokenTest()
+	public void WithBearerTokenShouldSetAuthorizationHeader()
 	{
 		string token = "test_token";
 		HttpRequestMessage httpRequestMessage = new();
@@ -24,7 +24,23 @@ public sealed class HttpRequestMessageExtensionsTests
 	}
 
 	[TestMethod]
-	public void WithMediaTypeTest()
+	public void WithBearerTokenWithNullShouldThrowArgumentNullException()
+	{
+		HttpRequestMessage httpRequestMessage = new();
+
+		Assert.Throws<ArgumentNullException>(() => httpRequestMessage.WithBearerToken(null!));
+	}
+
+	[TestMethod]
+	public void WithBearerTokenWithEmptyShouldThrowArgumentException()
+	{
+		HttpRequestMessage httpRequestMessage = new();
+
+		Assert.Throws<ArgumentException>(() => httpRequestMessage.WithBearerToken(string.Empty));
+	}
+
+	[TestMethod]
+	public void WithMediaTypeShouldAddMediaTypeToAcceptHeader()
 	{
 		string mediaType = "application/json";
 		HttpRequestMessage httpRequestMessage = new();
@@ -33,4 +49,16 @@ public sealed class HttpRequestMessageExtensionsTests
 
 		Assert.Contains(h => h.MediaType == mediaType, httpRequestMessage.Headers.Accept);
 	}
+
+	[TestMethod]
+	public void WithMediaTypeCalledTwiceShouldNotDuplicateEntry()
+	{
+		string mediaType = "application/json";
+		HttpRequestMessage httpRequestMessage = new();
+
+		httpRequestMessage.WithMediaType(mediaType).WithMediaType(mediaType);
+
+		Assert.HasCount(1, httpRequestMessage.Headers.Accept);
+	}
 }
+


### PR DESCRIPTION
**Changes:**

- Enhanced input validation and error handling for `HttpClient` and `HttpRequestMessage` extension methods, including null/empty checks and .NET 6+ support.
- Added `UriKind` overload for `WithBaseAddress`, prevented duplicate Accept headers, and expanded unit tests for new validation logic and edge cases.

closes #270 