### PR TITLE
feat(winforms): add `NumericUpDown` binding extensions for all key properties

### DIFF
--- a/src/BB84.WinForms.Extensions/NumericUpDownExtensions.cs
+++ b/src/BB84.WinForms.Extensions/NumericUpDownExtensions.cs
@@ -7,7 +7,9 @@ namespace BB84.WinForms.Extensions;
 
 /// <summary>
 /// Provides extension methods for binding properties of a <see cref="NumericUpDown"/> control to a data source,
-/// enabling streamlined data binding for common properties such as <see cref="NumericUpDown.Value"/>.
+/// enabling streamlined data binding for common properties such as <see cref="NumericUpDown.Value"/>,
+/// <see cref="NumericUpDown.Minimum"/>, <see cref="NumericUpDown.Maximum"/>,
+/// <see cref="NumericUpDown.Increment"/>, and <see cref="NumericUpDown.DecimalPlaces"/>.
 /// </summary>
 public static class NumericUpDownExtensions
 {
@@ -28,6 +30,86 @@ public static class NumericUpDownExtensions
 	public static NumericUpDown WithValueBinding(this NumericUpDown numericUpDown, object dataSource, string dataMember)
 	{
 		numericUpDown.DataBindings.Add(nameof(numericUpDown.Value), dataSource, dataMember, true, DataSourceUpdateMode.OnPropertyChanged);
+		return numericUpDown;
+	}
+
+	/// <summary>
+	/// Binds the <see cref="NumericUpDown.Minimum"/> property of the specified <see cref="NumericUpDown"/>
+	/// to a property on the provided data source.
+	/// </summary>
+	/// <remarks>
+	/// The binding is configured to update the data source whenever the <see cref="NumericUpDown.Minimum"/> 
+	/// property changes, using <see cref="DataSourceUpdateMode.OnPropertyChanged"/>.
+	/// </remarks>
+	/// <param name="numericUpDown">The <see cref="NumericUpDown"/> to bind.</param>
+	/// <param name="dataSource">The data source containing the property to bind to.</param>
+	/// <param name="dataMember">The name of the property on the data source to bind to.</param>
+	/// <returns>
+	/// The <see cref="NumericUpDown"/> control with the binding applied, allowing for method chaining.
+	/// </returns>
+	public static NumericUpDown WithMinimumBinding(this NumericUpDown numericUpDown, object dataSource, string dataMember)
+	{
+		numericUpDown.DataBindings.Add(nameof(numericUpDown.Minimum), dataSource, dataMember, true, DataSourceUpdateMode.OnPropertyChanged);
+		return numericUpDown;
+	}
+
+	/// <summary>
+	/// Binds the <see cref="NumericUpDown.Maximum"/> property of the specified <see cref="NumericUpDown"/>
+	/// to a property on the provided data source.
+	/// </summary>
+	/// <remarks>
+	/// The binding is configured to update the data source whenever the <see cref="NumericUpDown.Maximum"/> 
+	/// property changes, using <see cref="DataSourceUpdateMode.OnPropertyChanged"/>.
+	/// </remarks>
+	/// <param name="numericUpDown">The <see cref="NumericUpDown"/> to bind.</param>
+	/// <param name="dataSource">The data source containing the property to bind to.</param>
+	/// <param name="dataMember">The name of the property on the data source to bind to.</param>
+	/// <returns>
+	/// The <see cref="NumericUpDown"/> control with the binding applied, allowing for method chaining.
+	/// </returns>
+	public static NumericUpDown WithMaximumBinding(this NumericUpDown numericUpDown, object dataSource, string dataMember)
+	{
+		numericUpDown.DataBindings.Add(nameof(numericUpDown.Maximum), dataSource, dataMember, true, DataSourceUpdateMode.OnPropertyChanged);
+		return numericUpDown;
+	}
+
+	/// <summary>
+	/// Binds the <see cref="NumericUpDown.Increment"/> property of the specified <see cref="NumericUpDown"/>
+	/// to a property on the provided data source.
+	/// </summary>
+	/// <remarks>
+	/// The binding is configured to update the data source whenever the <see cref="NumericUpDown.Increment"/> 
+	/// property changes, using <see cref="DataSourceUpdateMode.OnPropertyChanged"/>.
+	/// </remarks>
+	/// <param name="numericUpDown">The <see cref="NumericUpDown"/> to bind.</param>
+	/// <param name="dataSource">The data source containing the property to bind to.</param>
+	/// <param name="dataMember">The name of the property on the data source to bind to.</param>
+	/// <returns>
+	/// The <see cref="NumericUpDown"/> control with the binding applied, allowing for method chaining.
+	/// </returns>
+	public static NumericUpDown WithIncrementBinding(this NumericUpDown numericUpDown, object dataSource, string dataMember)
+	{
+		numericUpDown.DataBindings.Add(nameof(numericUpDown.Increment), dataSource, dataMember, true, DataSourceUpdateMode.OnPropertyChanged);
+		return numericUpDown;
+	}
+
+	/// <summary>
+	/// Binds the <see cref="NumericUpDown.DecimalPlaces"/> property of the specified <see cref="NumericUpDown"/>
+	/// to a property on the provided data source.
+	/// </summary>
+	/// <remarks>
+	/// The binding is configured to update the data source whenever the <see cref="NumericUpDown.DecimalPlaces"/> 
+	/// property changes, using <see cref="DataSourceUpdateMode.OnPropertyChanged"/>.
+	/// </remarks>
+	/// <param name="numericUpDown">The <see cref="NumericUpDown"/> to bind.</param>
+	/// <param name="dataSource">The data source containing the property to bind to.</param>
+	/// <param name="dataMember">The name of the property on the data source to bind to.</param>
+	/// <returns>
+	/// The <see cref="NumericUpDown"/> control with the binding applied, allowing for method chaining.
+	/// </returns>
+	public static NumericUpDown WithDecimalPlacesBinding(this NumericUpDown numericUpDown, object dataSource, string dataMember)
+	{
+		numericUpDown.DataBindings.Add(nameof(numericUpDown.DecimalPlaces), dataSource, dataMember, true, DataSourceUpdateMode.OnPropertyChanged);
 		return numericUpDown;
 	}
 }

--- a/src/BB84.WinForms.Extensions/README.md
+++ b/src/BB84.WinForms.Extensions/README.md
@@ -44,9 +44,11 @@ public partial class MyForm : Form
 
         // Bind numeric up/down
         numericUpDown1
-            .BindValue(viewModel, nameof(MyViewModel.Count))
-            .BindMinimum(viewModel, nameof(MyViewModel.MinCount))
-            .BindMaximum(viewModel, nameof(MyViewModel.MaxCount));
+            .WithValueBinding(viewModel, nameof(MyViewModel.Count))
+            .WithMinimumBinding(viewModel, nameof(MyViewModel.MinCount))
+            .WithMaximumBinding(viewModel, nameof(MyViewModel.MaxCount))
+            .WithIncrementBinding(viewModel, nameof(MyViewModel.Step))
+            .WithDecimalPlacesBinding(viewModel, nameof(MyViewModel.Precision));
     }
 }
 ```

--- a/tests/BB84.WinForms.Extensions.Tests/NumericUpDownExtensionsTests.cs
+++ b/tests/BB84.WinForms.Extensions.Tests/NumericUpDownExtensionsTests.cs
@@ -21,4 +21,60 @@ public sealed class NumericUpDownExtensionsTests
 		Assert.AreEqual(dataSource, numericUpDown.DataBindings[0].DataSource);
 		Assert.AreEqual(DataSourceUpdateMode.OnPropertyChanged, numericUpDown.DataBindings[0].DataSourceUpdateMode);
 	}
+
+	[TestMethod]
+	public void WithMinimumBindingTest()
+	{
+		var dataSource = new { Minimum = 0m };
+		NumericUpDown numericUpDown = new();
+
+		numericUpDown.WithMinimumBinding(dataSource, nameof(numericUpDown.Minimum));
+
+		Assert.HasCount(1, numericUpDown.DataBindings);
+		Assert.AreEqual(nameof(numericUpDown.Minimum), numericUpDown.DataBindings[0].PropertyName);
+		Assert.AreEqual(dataSource, numericUpDown.DataBindings[0].DataSource);
+		Assert.AreEqual(DataSourceUpdateMode.OnPropertyChanged, numericUpDown.DataBindings[0].DataSourceUpdateMode);
+	}
+
+	[TestMethod]
+	public void WithMaximumBindingTest()
+	{
+		var dataSource = new { Maximum = 100m };
+		NumericUpDown numericUpDown = new();
+
+		numericUpDown.WithMaximumBinding(dataSource, nameof(numericUpDown.Maximum));
+
+		Assert.HasCount(1, numericUpDown.DataBindings);
+		Assert.AreEqual(nameof(numericUpDown.Maximum), numericUpDown.DataBindings[0].PropertyName);
+		Assert.AreEqual(dataSource, numericUpDown.DataBindings[0].DataSource);
+		Assert.AreEqual(DataSourceUpdateMode.OnPropertyChanged, numericUpDown.DataBindings[0].DataSourceUpdateMode);
+	}
+
+	[TestMethod]
+	public void WithIncrementBindingTest()
+	{
+		var dataSource = new { Increment = 1m };
+		NumericUpDown numericUpDown = new();
+
+		numericUpDown.WithIncrementBinding(dataSource, nameof(numericUpDown.Increment));
+
+		Assert.HasCount(1, numericUpDown.DataBindings);
+		Assert.AreEqual(nameof(numericUpDown.Increment), numericUpDown.DataBindings[0].PropertyName);
+		Assert.AreEqual(dataSource, numericUpDown.DataBindings[0].DataSource);
+		Assert.AreEqual(DataSourceUpdateMode.OnPropertyChanged, numericUpDown.DataBindings[0].DataSourceUpdateMode);
+	}
+
+	[TestMethod]
+	public void WithDecimalPlacesBindingTest()
+	{
+		var dataSource = new { DecimalPlaces = 2 };
+		NumericUpDown numericUpDown = new();
+
+		numericUpDown.WithDecimalPlacesBinding(dataSource, nameof(numericUpDown.DecimalPlaces));
+
+		Assert.HasCount(1, numericUpDown.DataBindings);
+		Assert.AreEqual(nameof(numericUpDown.DecimalPlaces), numericUpDown.DataBindings[0].PropertyName);
+		Assert.AreEqual(dataSource, numericUpDown.DataBindings[0].DataSource);
+		Assert.AreEqual(DataSourceUpdateMode.OnPropertyChanged, numericUpDown.DataBindings[0].DataSourceUpdateMode);
+	}
 }


### PR DESCRIPTION
**Changes:**

- Extended `NumericUpDownExtensions` with `WithMinimumBinding`, `WithMaximumBinding`, `WithIncrementBinding`, and `WithDecimalPlacesBinding` methods.
- Added unit tests for all new binding methods.
- Updated documentation and `README` with usage examples.

closes #263