### PR TITLE
feat(winforms): add `ToolStripItem` data binding extensions and tests

### DIFF
--- a/src/BB84.WinForms.Extensions/README.md
+++ b/src/BB84.WinForms.Extensions/README.md
@@ -49,6 +49,12 @@ public partial class MyForm : Form
             .WithMaximumBinding(viewModel, nameof(MyViewModel.MaxCount))
             .WithIncrementBinding(viewModel, nameof(MyViewModel.Step))
             .WithDecimalPlacesBinding(viewModel, nameof(MyViewModel.Precision));
+
+        // Bind tool strip items
+        toolStripButton1
+            .WithEnabledBinding(viewModel, nameof(MyViewModel.IsEditable))
+            .WithVisibleBinding(viewModel, nameof(MyViewModel.IsVisible))
+            .WithTextBinding(viewModel, nameof(MyViewModel.ButtonText));
     }
 }
 ```

--- a/src/BB84.WinForms.Extensions/ToolStripItemExtensions.cs
+++ b/src/BB84.WinForms.Extensions/ToolStripItemExtensions.cs
@@ -1,0 +1,80 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET8_0_OR_GREATER
+namespace BB84.WinForms.Extensions;
+
+/// <summary>
+/// Provides extension methods for the <see cref="ToolStripItem"/> class to simplify data binding.
+/// </summary>
+/// <remarks>
+/// This class includes methods to bind common properties of a <see cref="ToolStripItem"/>, such as
+/// <see cref="ToolStripItem.Enabled"/>, <see cref="ToolStripItem.Text"/> and
+/// <see cref="ToolStripItem.Visible"/>, to a specified data source. These methods return the same
+/// <see cref="ToolStripItem"/> instance, allowing for method chaining.
+/// </remarks>
+public static class ToolStripItemExtensions
+{
+	/// <summary>
+	/// Binds the <see cref="ToolStripItem.Enabled"/> property of the specified <see cref="ToolStripItem"/> to a
+	/// property on the provided data source.
+	/// </summary>
+	/// <remarks>
+	/// The binding is configured to update the data source whenever the <see cref="ToolStripItem.Enabled"/>
+	/// property changes, using <see cref="DataSourceUpdateMode.OnPropertyChanged"/>.
+	/// </remarks>
+	/// <param name="item">The <see cref="ToolStripItem"/> to bind.</param>
+	/// <param name="dataSource">The data source containing the property to bind to.</param>
+	/// <param name="dataMember">The name of the property on the data source to bind to.</param>
+	/// <returns>
+	/// The <see cref="ToolStripItem"/> with the binding applied, allowing for method chaining.
+	/// </returns>
+	public static ToolStripItem WithEnabledBinding(this ToolStripItem item, object dataSource, string dataMember)
+	{
+		item.DataBindings.Add(nameof(item.Enabled), dataSource, dataMember, true, DataSourceUpdateMode.OnPropertyChanged);
+		return item;
+	}
+
+	/// <summary>
+	/// Binds the <see cref="ToolStripItem.Text"/> property of the specified <see cref="ToolStripItem"/> to a
+	/// property on the provided data source.
+	/// </summary>
+	/// <remarks>
+	/// The binding is configured to update the data source whenever the <see cref="ToolStripItem.Text"/>
+	/// property changes, using <see cref="DataSourceUpdateMode.OnPropertyChanged"/>.
+	/// </remarks>
+	/// <param name="item">The <see cref="ToolStripItem"/> to bind.</param>
+	/// <param name="dataSource">The data source containing the property to bind to.</param>
+	/// <param name="dataMember">The name of the property on the data source to bind to.</param>
+	/// <returns>
+	/// The <see cref="ToolStripItem"/> with the binding applied, allowing for method chaining.
+	/// </returns>
+	public static ToolStripItem WithTextBinding(this ToolStripItem item, object dataSource, string dataMember)
+	{
+		item.DataBindings.Add(nameof(item.Text), dataSource, dataMember, true, DataSourceUpdateMode.OnPropertyChanged);
+		return item;
+	}
+
+	/// <summary>
+	/// Binds the <see cref="ToolStripItem.Visible"/> property of the specified <see cref="ToolStripItem"/> to a
+	/// property on the provided data source.
+	/// </summary>
+	/// <remarks>
+	/// The binding is configured to update the data source whenever the <see cref="ToolStripItem.Visible"/>
+	/// property changes, using <see cref="DataSourceUpdateMode.OnPropertyChanged"/>.
+	/// </remarks>
+	/// <param name="item">The <see cref="ToolStripItem"/> to bind.</param>
+	/// <param name="dataSource">The data source containing the property to bind to.</param>
+	/// <param name="dataMember">The name of the property on the data source to bind to.</param>
+	/// <returns>
+	/// The <see cref="ToolStripItem"/> with the binding applied, allowing for method chaining.
+	/// </returns>
+	public static ToolStripItem WithVisibleBinding(this ToolStripItem item, object dataSource, string dataMember)
+	{
+		item.DataBindings.Add(nameof(item.Visible), dataSource, dataMember, true, DataSourceUpdateMode.OnPropertyChanged);
+		return item;
+	}
+}
+#endif

--- a/tests/BB84.WinForms.Extensions.Tests/ToolStripItemExtensionsTests.cs
+++ b/tests/BB84.WinForms.Extensions.Tests/ToolStripItemExtensionsTests.cs
@@ -1,0 +1,88 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET8_0_OR_GREATER
+using System.Reflection;
+
+namespace BB84.WinForms.Extensions.Tests;
+
+[TestClass]
+public sealed class ToolStripItemExtensionsTests
+{
+	[TestMethod]
+	[DynamicData(nameof(TestData))]
+	public void WithEnabledBindingShouldBindEnabledProperty(ToolStripItem item)
+	{
+		var dataSource = new { Enabled = true };
+
+		item.WithEnabledBinding(dataSource, nameof(dataSource.Enabled));
+
+		Assert.HasCount(1, item.DataBindings);
+		Assert.AreEqual(nameof(item.Enabled), item.DataBindings[0].PropertyName);
+		Assert.AreEqual(dataSource, item.DataBindings[0].DataSource);
+		Assert.AreEqual(DataSourceUpdateMode.OnPropertyChanged, item.DataBindings[0].DataSourceUpdateMode);
+	}
+
+	[TestMethod]
+	[DynamicData(nameof(TestData))]
+	public void WithTextBindingShouldBindTextProperty(ToolStripItem item)
+	{
+		var dataSource = new { Text = "Test" };
+
+		item.WithTextBinding(dataSource, nameof(dataSource.Text));
+
+		Assert.HasCount(1, item.DataBindings);
+		Assert.AreEqual(nameof(item.Text), item.DataBindings[0].PropertyName);
+		Assert.AreEqual(dataSource, item.DataBindings[0].DataSource);
+		Assert.AreEqual(DataSourceUpdateMode.OnPropertyChanged, item.DataBindings[0].DataSourceUpdateMode);
+	}
+
+	[TestMethod]
+	[DynamicData(nameof(TestData))]
+	public void WithVisibleBindingShouldBindVisibleProperty(ToolStripItem item)
+	{
+		var dataSource = new { Visible = true };
+
+		item.WithVisibleBinding(dataSource, nameof(dataSource.Visible));
+
+		Assert.HasCount(1, item.DataBindings);
+		Assert.AreEqual(nameof(item.Visible), item.DataBindings[0].PropertyName);
+		Assert.AreEqual(dataSource, item.DataBindings[0].DataSource);
+		Assert.AreEqual(DataSourceUpdateMode.OnPropertyChanged, item.DataBindings[0].DataSourceUpdateMode);
+	}
+
+	private static List<ToolStripItem> GetToolStripItems()
+	{
+		Assembly assembly = typeof(ToolStripItem).Assembly;
+
+		IEnumerable<Type> types = assembly.GetTypes()
+			.Where(t => typeof(ToolStripItem).IsAssignableFrom(t) && !t.IsAbstract);
+
+		List<ToolStripItem> items = [];
+
+		foreach (Type type in types)
+		{
+			try
+			{
+				if (Activator.CreateInstance(type) is ToolStripItem item)
+					items.Add(item);
+			}
+			catch (Exception ex)
+			{
+				// Handle exceptions for types that cannot be instantiated
+				Console.WriteLine($"Could not create instance of {type.Name}: {ex.Message}");
+			}
+		}
+
+		return items;
+	}
+
+	private static IEnumerable<object[]> TestData()
+	{
+		foreach (ToolStripItem item in GetToolStripItems())
+			yield return new object[] { item };
+	}
+}
+#endif


### PR DESCRIPTION
**Changes:**

- Introduced `WithEnabledBinding`, `WithTextBinding`, and `WithVisibleBinding` extension methods for `ToolStripItem` to simplify property data binding with method chaining.
- Added unit tests covering all non-abstract `ToolStripItem` types.
- Updated `README` with usage examples.

closes #266 