### PR TITLE
feat(extensions): add `DateOnly`/`TimeOnly` extensions

### DIFF
--- a/src/BB84.Extensions/DateOnlyExtensions.cs
+++ b/src/BB84.Extensions/DateOnlyExtensions.cs
@@ -1,0 +1,119 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET6_0_OR_GREATER
+using System.Globalization;
+
+namespace BB84.Extensions;
+
+/// <summary>
+/// Provides extension methods for <see cref="DateOnly"/> to simplify common date-related calculations,
+/// such as determining the start or end of a month, week, or year, as well as calculating the week of
+/// the year.
+/// </summary>
+/// <remarks>
+/// These methods mirror the functionality available in <see cref="DateTimeExtensions"/> and are
+/// designed for use with the <see cref="DateOnly"/> type introduced in .NET 6.
+/// </remarks>
+public static class DateOnlyExtensions
+{
+	/// <summary>
+	/// Calculates the last day of the month for the specified <paramref name="value"/>.
+	/// </summary>
+	/// <remarks>
+	/// This method determines the end of the month by calculating the first day of the next month and
+	/// subtracting one day.
+	/// </remarks>
+	/// <param name="value">The date for which to determine the last day of the month.</param>
+	/// <returns>A <see cref="DateOnly"/> instance representing the last day of the month.</returns>
+	public static DateOnly EndOfMonth(this DateOnly value)
+		=> value.ToDateTime().EndOfMonth().ToDateOnly();
+
+	/// <summary>
+	/// Calculates the end date of the week for the specified <paramref name="value"/>, based on the
+	/// given start day of the week.
+	/// </summary>
+	/// <remarks>
+	/// The method assumes a 7-day week and calculates the end of the week by adding six days to the
+	/// start of the week. The result is based on the <paramref name="startOfWeek"/> parameter, which
+	/// determines the first day of the week.
+	/// </remarks>
+	/// <param name="value">The date for which to calculate the end of the week.</param>
+	/// <param name="startOfWeek">The day considered as the start of the week.</param>
+	/// <returns>A <see cref="DateOnly"/> instance representing the last day of the week.</returns>
+	public static DateOnly EndOfWeek(this DateOnly value, DayOfWeek startOfWeek = DayOfWeek.Monday)
+		=> value.ToDateTime().EndOfWeek(startOfWeek).ToDateOnly();
+
+	/// <summary>
+	/// Calculates the last day of the year for the specified <paramref name="value"/>.
+	/// </summary>
+	/// <remarks>
+	/// This method calculates the end of the year by determining the first day of the next year and
+	/// subtracting one day.
+	/// </remarks>
+	/// <param name="value">The <see cref="DateOnly"/> value for which to determine the end of the year.</param>
+	/// <returns>A <see cref="DateOnly"/> instance representing the last day of the year.</returns>
+	public static DateOnly EndOfYear(this DateOnly value)
+		=> value.ToDateTime().EndOfYear().ToDateOnly();
+
+	/// <summary>
+	/// Calculates the first day of the month for the specified <paramref name="value"/>.
+	/// </summary>
+	/// <param name="value">The date for which to determine the first day of the month.</param>
+	/// <returns>A <see cref="DateOnly"/> instance representing the first day of the month.</returns>
+	public static DateOnly StartOfMonth(this DateOnly value)
+		=> value.ToDateTime().StartOfMonth().ToDateOnly();
+
+	/// <summary>
+	/// Calculates the date of the start of the week for the specified <paramref name="value"/>,
+	/// using the provided <paramref name="startOfWeek"/> as the first day of the week.
+	/// </summary>
+	/// <remarks>
+	/// This method calculates the start of the week by determining the difference between the specified
+	/// date's day of the week and the provided <paramref name="startOfWeek"/>. The result is adjusted to
+	/// ensure it falls within the same week.
+	/// </remarks>
+	/// <param name="value">The date for which to calculate the start of the week.</param>
+	/// <param name="startOfWeek">The day to consider as the first day of the week.</param>
+	/// <returns>A <see cref="DateOnly"/> instance representing the start of the week.</returns>
+	public static DateOnly StartOfWeek(this DateOnly value, DayOfWeek startOfWeek = DayOfWeek.Monday)
+		=> value.ToDateTime().StartOfWeek(startOfWeek).ToDateOnly();
+
+	/// <summary>
+	/// Returns a <see cref="DateOnly"/> representing the first day of the year for the specified
+	/// <paramref name="value"/>.
+	/// </summary>
+	/// <param name="value">The date for which the start of the year is calculated.</param>
+	/// <returns>A <see cref="DateOnly"/> instance representing the start of the year.</returns>
+	public static DateOnly StartOfYear(this DateOnly value)
+		=> value.ToDateTime().StartOfYear().ToDateOnly();
+
+	/// <summary>
+	/// Calculates the week of the year for the specified <paramref name="value"/>.
+	/// </summary>
+	/// <remarks>
+	/// When using the default parameters (<see cref="CalendarWeekRule.FirstFourDayWeek"/> and
+	/// <see cref="DayOfWeek.Monday"/>), this method returns an ISO 8601-compliant week number.
+	/// </remarks>
+	/// <param name="value">The <see cref="DateOnly"/> value for which to determine the week of the year.</param>
+	/// <param name="rule">The <see cref="CalendarWeekRule"/> to use for the calculation.</param>
+	/// <param name="firstDayOfWeek">The <see cref="DayOfWeek"/> that is considered the first day of the week.</param>
+	/// <returns>An integer representing the week of the year.</returns>
+	public static int WeekOfYear(this DateOnly value, CalendarWeekRule rule = CalendarWeekRule.FirstFourDayWeek, DayOfWeek firstDayOfWeek = DayOfWeek.Monday)
+		=> value.ToDateTime().WeekOfYear(rule, firstDayOfWeek);
+
+	/// <summary>
+	/// Converts a <see cref="DateOnly"/> to a <see cref="DateTime"/> by combining it with the specified
+	/// <see cref="TimeOnly"/>. If no time is provided, the resulting <see cref="DateTime"/> will have the
+	/// default time of 00:00:00.000.
+	/// </summary>
+	/// <param name="date">The <see cref="DateOnly"/> to convert.</param>
+	/// <param name="time">The optional <see cref="TimeOnly"/> to combine with the date.</param>
+	/// <returns>A <see cref="DateTime"/> representing the combined date and time.</returns>
+	public static DateTime ToDateTime(this DateOnly date, TimeOnly? time = null) => time is null
+			? new DateTime(date.Year, date.Month, date.Day, 0, 0, 0, 0, DateTimeKind.Unspecified)
+			: new DateTime(date.Year, date.Month, date.Day, time.Value.Hour, time.Value.Minute, time.Value.Second, time.Value.Millisecond, DateTimeKind.Unspecified);
+}
+#endif

--- a/src/BB84.Extensions/DateTimeExtensions.cs
+++ b/src/BB84.Extensions/DateTimeExtensions.cs
@@ -155,25 +155,43 @@ public static class DateTimeExtensions
 	}
 
 	/// <summary>
-	/// Calculates the week of the year for the specified <paramref name="value"/> according to the ISO 8601 standard.
+	/// Calculates the week of the year for the specified <paramref name="value"/>.
 	/// </summary>
 	/// <remarks>
-	/// This method uses the <see cref="CultureInfo.InvariantCulture"/> calendar to calculate the week of the year.
-	/// If the specified date falls on a Monday, Tuesday, or Wednesday, it adjusts the date forward by three days
-	/// to ensure correct week calculation according to the ISO 8601 standard.
+	/// When using the default parameters (<see cref="CalendarWeekRule.FirstFourDayWeek"/> and
+	/// <see cref="DayOfWeek.Monday"/>), this method returns an ISO 8601-compliant week number.
 	/// </remarks>
 	/// <param name="value">The <see cref="DateTime"/> value for which to determine the week of the year.</param>
-	/// <returns>
-	/// An integer representing the week of the year, based on the ISO 8601 standard, where the first week of the year
-	/// is the one containing at least four days and Monday is considered the first day of the week.
-	/// </returns>
-	public static int WeekOfYear(this DateTime value)
+	/// <param name="rule">The <see cref="CalendarWeekRule"/> to use for the calculation.</param>
+	/// <param name="firstDayOfWeek">The <see cref="DayOfWeek"/> that is considered the first day of the week.</param>
+	/// <returns>An integer representing the week of the year.</returns>
+	public static int WeekOfYear(this DateTime value, CalendarWeekRule rule = CalendarWeekRule.FirstFourDayWeek, DayOfWeek firstDayOfWeek = DayOfWeek.Monday)
 	{
 		DayOfWeek day = CultureInfo.InvariantCulture.Calendar.GetDayOfWeek(value);
 
 		if (day is >= DayOfWeek.Monday and <= DayOfWeek.Wednesday)
 			value = value.AddDays(3);
 
-		return CultureInfo.InvariantCulture.Calendar.GetWeekOfYear(value, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday);
+		return CultureInfo.InvariantCulture.Calendar.GetWeekOfYear(value, rule, firstDayOfWeek);
 	}
+#if NET6_0_OR_GREATER
+
+	/// <summary>
+	/// Converts a <see cref="DateTime"/> to a <see cref="DateOnly"/> by extracting the date component and discarding
+	/// the time component.
+	/// </summary>
+	/// <param name="value">The <see cref="DateTime"/> to convert.</param>
+	/// <returns>A <see cref="DateOnly"/> representing the date component of the <see cref="DateTime"/>.</returns>
+	public static DateOnly ToDateOnly(this DateTime value)
+		=> DateOnly.FromDateTime(value);
+
+	/// <summary>
+	/// Converts a <see cref="DateTime"/> to a <see cref="TimeOnly"/> by extracting the time component and discarding
+	/// the date component.
+	/// </summary>
+	/// <param name="value">The <see cref="DateTime"/> to convert.</param>
+	/// <returns>A <see cref="TimeOnly"/> representing the time component of the <see cref="DateTime"/>.</returns>
+	public static TimeOnly ToTimeOnly(this DateTime value)
+		=> TimeOnly.FromDateTime(value);
+#endif
 }

--- a/src/BB84.Extensions/README.md
+++ b/src/BB84.Extensions/README.md
@@ -42,6 +42,27 @@ IEnumerable<string> strings = ["a", "ab", "b", "bb"];
 strings.ForEach(x => x.Contains("a"), x => hits++);
 ```
 
+### Start of DateOnly month
+
+The `StartOfMonth` method returns the first day of the month for a given `DateOnly` value. The companion method `EndOfMonth` returns the last day.
+
+```csharp
+DateOnly today = new(2023, 9, 15);
+DateOnly start = today.StartOfMonth(); // 2023-09-01
+DateOnly end   = today.EndOfMonth();   // 2023-09-30
+```
+
+Equivalent helpers `StartOfWeek`, `EndOfWeek`, `StartOfYear`, `EndOfYear`, and `WeekOfYear` are also available.
+
+### TimeOnly range check
+
+The `IsBetween` method returns whether a `TimeOnly` value falls within a given range (start inclusive, end exclusive), correctly handling midnight-crossing ranges.
+
+```csharp
+TimeOnly value = new(23, 30);
+bool night = value.IsBetween(new TimeOnly(22, 0), new TimeOnly(2, 0)); // true
+```
+
 ### Color to RGB hexadecimal representation
 
 The `ToRGBHexString` method turns any `System.Drawing.Color` into its RGB hexadecimal string representation, with the prefix '#'.

--- a/src/BB84.Extensions/TimeOnlyExtensions.cs
+++ b/src/BB84.Extensions/TimeOnlyExtensions.cs
@@ -1,0 +1,47 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET6_0_OR_GREATER
+namespace BB84.Extensions;
+
+/// <summary>
+/// Provides extension methods for <see cref="TimeOnly"/> to simplify common time-related calculations.
+/// </summary>
+public static class TimeOnlyExtensions
+{
+	/// <summary>
+	/// Determines whether the specified <paramref name="value"/> falls within the time range
+	/// [<paramref name="start"/>, <paramref name="end"/>), where the start is inclusive and the end
+	/// is exclusive.
+	/// </summary>
+	/// <remarks>
+	/// When <paramref name="start"/> is less than or equal to <paramref name="end"/>, the range is
+	/// treated as a normal (non-midnight-crossing) range. When <paramref name="start"/> is greater
+	/// than <paramref name="end"/>, the range is treated as a midnight-crossing range (e.g., 22:00 to
+	/// 02:00).
+	/// </remarks>
+	/// <param name="value">The <see cref="TimeOnly"/> value to check.</param>
+	/// <param name="start">The inclusive start of the time range.</param>
+	/// <param name="end">The exclusive end of the time range.</param>
+	/// <returns>
+	/// <see langword="true"/> if <paramref name="value"/> is within the range; otherwise,
+	/// <see langword="false"/>.
+	/// </returns>
+	public static bool IsBetween(this TimeOnly value, TimeOnly start, TimeOnly end)
+		=> start <= end ? value >= start && value < end : value >= start || value < end;
+
+	/// <summary>
+	/// Converts a <see cref="TimeOnly"/> to a <see cref="DateTime"/> by combining it with the specified
+	/// <see cref="DateOnly"/>. If no date is provided, the resulting <see cref="DateTime"/> will have the
+	/// default date of 0001-01-01.
+	/// </summary>
+	/// <param name="time">The <see cref="TimeOnly"/> to convert.</param>
+	/// <param name="date">The optional <see cref="DateOnly"/> to combine with the time.</param>
+	/// <returns>A <see cref="DateTime"/> representing the combined date and time.</returns>
+	public static DateTime ToDateTime(this TimeOnly time, DateOnly? date = null) => date is null
+			? new DateTime(1, 1, 1, time.Hour, time.Minute, time.Second, time.Millisecond, DateTimeKind.Unspecified)
+			: new DateTime(date.Value.Year, date.Value.Month, date.Value.Day, time.Hour, time.Minute, time.Second, time.Millisecond, DateTimeKind.Unspecified);
+}
+#endif

--- a/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.EndOfMonth.cs
+++ b/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.EndOfMonth.cs
@@ -1,0 +1,16 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET6_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+public sealed partial class DateOnlyExtensionsTests
+{
+	[TestMethod]
+	[DynamicData(nameof(GetEndOfMonthTestData))]
+	public void EndOfMonthTest(DateOnly value, DateOnly expected)
+		=> Assert.AreEqual(expected, value.EndOfMonth());
+}
+#endif

--- a/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.EndOfWeek.cs
+++ b/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.EndOfWeek.cs
@@ -1,0 +1,16 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET6_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+public sealed partial class DateOnlyExtensionsTests
+{
+	[TestMethod]
+	[DynamicData(nameof(GetEndOfWeekTestData))]
+	public void EndOfWeekTest(DateOnly value, DateOnly expected)
+		=> Assert.AreEqual(expected, value.EndOfWeek());
+}
+#endif

--- a/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.EndOfYear.cs
+++ b/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.EndOfYear.cs
@@ -1,0 +1,16 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET6_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+public sealed partial class DateOnlyExtensionsTests
+{
+	[TestMethod]
+	[DynamicData(nameof(GetEndOfYearTestData))]
+	public void EndOfYearTest(DateOnly value, DateOnly expected)
+		=> Assert.AreEqual(expected, value.EndOfYear());
+}
+#endif

--- a/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.StartOfMonth.cs
+++ b/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.StartOfMonth.cs
@@ -1,0 +1,16 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET6_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+public sealed partial class DateOnlyExtensionsTests
+{
+	[TestMethod]
+	[DynamicData(nameof(GetStartOfMonthTestData))]
+	public void StartOfMonthTest(DateOnly value, DateOnly expected)
+		=> Assert.AreEqual(expected, value.StartOfMonth());
+}
+#endif

--- a/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.StartOfWeek.cs
+++ b/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.StartOfWeek.cs
@@ -1,0 +1,16 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET6_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+public sealed partial class DateOnlyExtensionsTests
+{
+	[TestMethod]
+	[DynamicData(nameof(GetStartOfWeekTestData))]
+	public void StartOfWeekTest(DateOnly value, DateOnly expected)
+		=> Assert.AreEqual(expected, value.StartOfWeek());
+}
+#endif

--- a/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.StartOfYear.cs
+++ b/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.StartOfYear.cs
@@ -1,0 +1,16 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET6_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+public sealed partial class DateOnlyExtensionsTests
+{
+	[TestMethod]
+	[DynamicData(nameof(GetStartOfYearTestData))]
+	public void StartOfYearTest(DateOnly value, DateOnly expected)
+		=> Assert.AreEqual(expected, value.StartOfYear());
+}
+#endif

--- a/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.WeekOfYear.cs
+++ b/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.WeekOfYear.cs
@@ -1,0 +1,16 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET6_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+public sealed partial class DateOnlyExtensionsTests
+{
+	[TestMethod]
+	[DynamicData(nameof(GetWeekOfYearTestData))]
+	public void WeekOfYearTest(DateOnly value, int expected)
+		=> Assert.AreEqual(expected, value.WeekOfYear());
+}
+#endif

--- a/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.cs
+++ b/tests/BB84.Extensions.Tests/DateOnlyExtensionsTests.cs
@@ -1,0 +1,75 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET6_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+[TestClass]
+public sealed partial class DateOnlyExtensionsTests
+{
+	public static IEnumerable<object[]> GetStartOfMonthTestData()
+	{
+		yield return new object[] { new DateOnly(2023, 9, 5), new DateOnly(2023, 9, 1) };
+		yield return new object[] { new DateOnly(2023, 9, 6), new DateOnly(2023, 9, 1) };
+		yield return new object[] { new DateOnly(2023, 9, 7), new DateOnly(2023, 9, 1) };
+		yield return new object[] { new DateOnly(2023, 9, 8), new DateOnly(2023, 9, 1) };
+		yield return new object[] { new DateOnly(2023, 9, 9), new DateOnly(2023, 9, 1) };
+	}
+
+	public static IEnumerable<object[]> GetEndOfMonthTestData()
+	{
+		yield return new object[] { new DateOnly(2023, 9, 5), new DateOnly(2023, 9, 30) };
+		yield return new object[] { new DateOnly(2023, 9, 6), new DateOnly(2023, 9, 30) };
+		yield return new object[] { new DateOnly(2023, 9, 7), new DateOnly(2023, 9, 30) };
+		yield return new object[] { new DateOnly(2024, 2, 1), new DateOnly(2024, 2, 29) };
+		yield return new object[] { new DateOnly(2023, 2, 1), new DateOnly(2023, 2, 28) };
+	}
+
+	public static IEnumerable<object[]> GetStartOfWeekTestData()
+	{
+		yield return new object[] { new DateOnly(2023, 9, 5), new DateOnly(2023, 9, 4) };
+		yield return new object[] { new DateOnly(2023, 9, 6), new DateOnly(2023, 9, 4) };
+		yield return new object[] { new DateOnly(2023, 9, 7), new DateOnly(2023, 9, 4) };
+		yield return new object[] { new DateOnly(2023, 9, 8), new DateOnly(2023, 9, 4) };
+		yield return new object[] { new DateOnly(2023, 9, 9), new DateOnly(2023, 9, 4) };
+	}
+
+	public static IEnumerable<object[]> GetEndOfWeekTestData()
+	{
+		yield return new object[] { new DateOnly(2023, 9, 5), new DateOnly(2023, 9, 10) };
+		yield return new object[] { new DateOnly(2023, 9, 6), new DateOnly(2023, 9, 10) };
+		yield return new object[] { new DateOnly(2023, 9, 7), new DateOnly(2023, 9, 10) };
+		yield return new object[] { new DateOnly(2023, 9, 8), new DateOnly(2023, 9, 10) };
+		yield return new object[] { new DateOnly(2023, 9, 9), new DateOnly(2023, 9, 10) };
+	}
+
+	public static IEnumerable<object[]> GetStartOfYearTestData()
+	{
+		yield return new object[] { new DateOnly(2023, 9, 5), new DateOnly(2023, 1, 1) };
+		yield return new object[] { new DateOnly(2023, 4, 6), new DateOnly(2023, 1, 1) };
+		yield return new object[] { new DateOnly(2022, 9, 7), new DateOnly(2022, 1, 1) };
+		yield return new object[] { new DateOnly(2013, 9, 8), new DateOnly(2013, 1, 1) };
+		yield return new object[] { new DateOnly(2024, 12, 31), new DateOnly(2024, 1, 1) };
+	}
+
+	public static IEnumerable<object[]> GetEndOfYearTestData()
+	{
+		yield return new object[] { new DateOnly(2023, 9, 5), new DateOnly(2023, 12, 31) };
+		yield return new object[] { new DateOnly(2023, 5, 6), new DateOnly(2023, 12, 31) };
+		yield return new object[] { new DateOnly(2021, 1, 7), new DateOnly(2021, 12, 31) };
+		yield return new object[] { new DateOnly(2022, 12, 8), new DateOnly(2022, 12, 31) };
+		yield return new object[] { new DateOnly(2024, 4, 9), new DateOnly(2024, 12, 31) };
+	}
+
+	public static IEnumerable<object[]> GetWeekOfYearTestData()
+	{
+		yield return new object[] { new DateOnly(2000, 3, 31), 13 };
+		yield return new object[] { new DateOnly(1900, 5, 31), 22 };
+		yield return new object[] { new DateOnly(2100, 12, 31), 52 };
+		yield return new object[] { new DateOnly(2200, 10, 31), 44 };
+		yield return new object[] { new DateOnly(2300, 8, 31), 35 };
+	}
+}
+#endif

--- a/tests/BB84.Extensions.Tests/TimeOnlyExtensionsTests.IsBetween.cs
+++ b/tests/BB84.Extensions.Tests/TimeOnlyExtensionsTests.IsBetween.cs
@@ -1,0 +1,16 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET6_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+public sealed partial class TimeOnlyExtensionsTests
+{
+	[TestMethod]
+	[DynamicData(nameof(GetIsBetweenTestData))]
+	public void IsBetweenTest(TimeOnly value, TimeOnly start, TimeOnly end, bool expected)
+		=> Assert.AreEqual(expected, value.IsBetween(start, end));
+}
+#endif

--- a/tests/BB84.Extensions.Tests/TimeOnlyExtensionsTests.cs
+++ b/tests/BB84.Extensions.Tests/TimeOnlyExtensionsTests.cs
@@ -1,0 +1,29 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET6_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+[TestClass]
+public sealed partial class TimeOnlyExtensionsTests
+{
+	public static IEnumerable<object[]> GetIsBetweenTestData()
+	{
+		// Normal range (no midnight crossing)
+		yield return new object[] { new TimeOnly(10, 0), new TimeOnly(9, 0), new TimeOnly(11, 0), true };
+		yield return new object[] { new TimeOnly(9, 0), new TimeOnly(9, 0), new TimeOnly(11, 0), true };
+		yield return new object[] { new TimeOnly(11, 0), new TimeOnly(9, 0), new TimeOnly(11, 0), false };
+		yield return new object[] { new TimeOnly(8, 59), new TimeOnly(9, 0), new TimeOnly(11, 0), false };
+		yield return new object[] { new TimeOnly(11, 1), new TimeOnly(9, 0), new TimeOnly(11, 0), false };
+
+		// Midnight-crossing range
+		yield return new object[] { new TimeOnly(23, 0), new TimeOnly(22, 0), new TimeOnly(2, 0), true };
+		yield return new object[] { new TimeOnly(0, 0), new TimeOnly(22, 0), new TimeOnly(2, 0), true };
+		yield return new object[] { new TimeOnly(2, 0), new TimeOnly(22, 0), new TimeOnly(2, 0), false };
+		yield return new object[] { new TimeOnly(3, 0), new TimeOnly(22, 0), new TimeOnly(2, 0), false };
+		yield return new object[] { new TimeOnly(21, 59), new TimeOnly(22, 0), new TimeOnly(2, 0), false };
+	}
+}
+#endif


### PR DESCRIPTION
**Changes:**

- Added extension methods for `DateOnly` and `TimeOnly` (`StartOfMonth`, `EndOfMonth`, `StartOfWeek`, `EndOfWeek`, `StartOfYear`, `EndOfYear`, `WeekOfYear`, `IsBetween`) in `BB84.Extensions` for .NET 6+.
- Enhanced `DateTimeExtensions.WeekOfYear` for ISO 8601 compliance.
- Included conversion helpers, XML docs, copyright/license headers, comprehensive unit tests.
- Updated `README` with usage examples.

closes #261 