### PR TITLE
feat(extensions): add `IsBetween` extension with docs and tests

### DIFF
--- a/src/BB84.Extensions/ComparableExtensions.cs
+++ b/src/BB84.Extensions/ComparableExtensions.cs
@@ -78,4 +78,38 @@ public static class ComparableExtensions
 	/// </returns>
 	public static bool IsLessThan<T>(this T value, T comparativeValue) where T : IComparable
 		=> value.CompareTo(comparativeValue) < 0;
+
+	/// <summary>
+	/// Determines whether the current value falls within the range defined by <paramref name="min"/> and
+	/// <paramref name="max"/>.
+	/// </summary>
+	/// <remarks>
+	/// This method uses the <see cref="IComparable.CompareTo"/> method to perform the comparison.
+	/// When <paramref name="inclusive"/> is <see langword="true"/> (the default), the comparison is
+	/// <c>min &lt;= value &lt;= max</c>. When <see langword="false"/>, the comparison is
+	/// <c>min &lt; value &lt; max</c>.
+	/// </remarks>
+	/// <typeparam name="T">The type of the values being compared.</typeparam>
+	/// <param name="value">The value to check.</param>
+	/// <param name="min">The lower bound of the range.</param>
+	/// <param name="max">The upper bound of the range.</param>
+	/// <param name="inclusive">
+	/// When <see langword="true"/>, the range boundaries are included; otherwise, they are excluded.
+	/// </param>
+	/// <returns>
+	/// <see langword="true"/> if <paramref name="value"/> is within the range; otherwise,
+	/// <see langword="false"/>.
+	/// </returns>
+	/// <exception cref="ArgumentOutOfRangeException">
+	/// Thrown when <paramref name="min"/> is greater than <paramref name="max"/>.
+	/// </exception>
+	public static bool IsBetween<T>(this T value, T min, T max, bool inclusive = true) where T : IComparable
+	{
+		if (min.CompareTo(max) > 0)
+			throw new ArgumentOutOfRangeException(nameof(min), $"The parameter {nameof(min)} must not be greater than {nameof(max)}.");
+
+		return inclusive
+			? value.CompareTo(min) >= 0 && value.CompareTo(max) <= 0
+			: value.CompareTo(min) > 0 && value.CompareTo(max) < 0;
+	}
 }

--- a/src/BB84.Extensions/README.md
+++ b/src/BB84.Extensions/README.md
@@ -23,6 +23,18 @@ DateTime today = new(2023, 9, 5);
 DateTime startOfWeek = today.StartOfWeek();
 ```
 
+### Range check
+
+The `IsBetween` method determines whether a comparable value falls within a given range. The bounds are inclusive by default; pass `inclusive: false` for an exclusive range. Throws `ArgumentOutOfRangeException` if `min` is greater than `max`.
+
+```csharp
+int value = 5;
+bool inRange = value.IsBetween(1, 10);          // true  (inclusive)
+bool inRangeEx = value.IsBetween(1, 10, false); // true  (exclusive)
+bool onBound = 10.IsBetween(1, 10);             // true  (inclusive boundary)
+bool onBoundEx = 10.IsBetween(1, 10, false);    // false (exclusive boundary)
+```
+
 ### Random choice
 
 The `TakeRandom` method returns a randomly chosen item from a given array.

--- a/tests/BB84.Extensions.Tests/ComparableExtensionsTests.IsBetween.cs
+++ b/tests/BB84.Extensions.Tests/ComparableExtensionsTests.IsBetween.cs
@@ -1,0 +1,29 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.Extensions.Tests;
+
+public partial class ComparableExtensionsTests
+{
+	// Inclusive (default)
+	[DataRow(5, 1, 10, true, true)]
+	[DataRow(1, 1, 10, true, true)]
+	[DataRow(10, 1, 10, true, true)]
+	[DataRow(0, 1, 10, true, false)]
+	[DataRow(11, 1, 10, true, false)]
+	// Exclusive
+	[DataRow(5, 1, 10, false, true)]
+	[DataRow(1, 1, 10, false, false)]
+	[DataRow(10, 1, 10, false, false)]
+	[DataRow(0, 1, 10, false, false)]
+	[DataRow(11, 1, 10, false, false)]
+	[TestMethod]
+	public void IsBetween(int value, int min, int max, bool inclusive, bool expected)
+		=> Assert.AreEqual(expected, value.IsBetween(min, max, inclusive));
+
+	[TestMethod]
+	public void IsBetweenShouldThrowArgumentOutOfRangeException()
+		=> Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => 5.IsBetween(10, 1));
+}


### PR DESCRIPTION
**Changes:**

- Implemented `IsBetween` for `IComparable` types with support for inclusive/exclusive bounds and min/max validation.
- Added comprehensive unit tests, including exception handling.
- Updated `README.md` with usage examples.

closes #260 