### PR TITLE
feat(extensions): add `Chunk` extension for `IEnumerable<T>` with tests

### DIFF
--- a/src/BB84.Extensions/EnumerableExtensions.cs
+++ b/src/BB84.Extensions/EnumerableExtensions.cs
@@ -164,4 +164,67 @@ public static class EnumerableExtensions
 	/// </returns>
 	public static bool TryTakeRandom<T>(this IEnumerable<T> values, [MaybeNullWhen(false)] out T result)
 		=> values.ToArray().TryTakeRandom(out result);
+
+	/// <summary>
+	/// Splits the elements of <paramref name="values"/> into chunks of at most
+	/// <paramref name="size"/> elements each. The last chunk will contain the remaining elements
+	/// if the sequence length is not evenly divisible by <paramref name="size"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of elements in the sequence.</typeparam>
+	/// <param name="values">The sequence to partition.</param>
+	/// <param name="size">The maximum number of elements in each chunk.</param>
+	/// <returns>
+	/// An <see cref="IEnumerable{T}"/> of <typeparamref name="T"/>[] where each array contains
+	/// at most <paramref name="size"/> elements.
+	/// </returns>
+	/// <exception cref="ArgumentNullException">
+	/// Thrown when <paramref name="values"/> is <see langword="null"/>.
+	/// </exception>
+	/// <exception cref="ArgumentOutOfRangeException">
+	/// Thrown when <paramref name="size"/> is less than or equal to zero.
+	/// </exception>
+	public static IEnumerable<T[]> Chunk<T>(this IEnumerable<T> values, int size)
+	{
+#if NET6_0_OR_GREATER
+		ArgumentNullException.ThrowIfNull(values);
+#else
+		if (values is null)
+			throw new ArgumentNullException(nameof(values));
+#endif
+		if (size <= 0)
+			throw new ArgumentOutOfRangeException(nameof(size), "Size must be greater than zero.");
+
+#if NET6_0_OR_GREATER
+		return Enumerable.Chunk(values, size);
+#else
+		return ChunkIterator(values, size);
+#endif
+	}
+
+#if !NET6_0_OR_GREATER
+	private static IEnumerable<T[]> ChunkIterator<T>(IEnumerable<T> values, int size)
+	{
+		T[] chunk = new T[size];
+		int index = 0;
+
+		foreach (T value in values)
+		{
+			chunk[index++] = value;
+
+			if (index == size)
+			{
+				yield return chunk;
+				chunk = new T[size];
+				index = 0;
+			}
+		}
+
+		if (index > 0)
+		{
+			T[] remainder = new T[index];
+			Array.Copy(chunk, remainder, index);
+			yield return remainder;
+		}
+	}
+#endif
 }

--- a/src/BB84.Extensions/README.md
+++ b/src/BB84.Extensions/README.md
@@ -75,6 +75,20 @@ IEnumerable<string> strings = ["a", "ab", "b", "bb"];
 strings.ForEach(x => x.Contains("a"), x => hits++);
 ```
 
+### Chunk
+
+The `Chunk` method splits a sequence into arrays of at most `size` elements. The final chunk contains the remaining elements when the sequence length is not evenly divisible by `size`.
+
+```csharp
+IEnumerable<int> values = [1, 2, 3, 4, 5];
+foreach (int[] chunk in values.Chunk(2))
+    Console.WriteLine(string.Join(", ", chunk));
+// Output:
+// 1, 2
+// 3, 4
+// 5
+```
+
 ### Start of DateOnly month
 
 The `StartOfMonth` method returns the first day of the month for a given `DateOnly` value. The companion method `EndOfMonth` returns the last day.

--- a/tests/BB84.Extensions.Tests/EnumerableExtensionsTests.Chunk.cs
+++ b/tests/BB84.Extensions.Tests/EnumerableExtensionsTests.Chunk.cs
@@ -1,0 +1,103 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.Extensions.Tests;
+
+public sealed partial class EnumerableExtensionsTests
+{
+	[TestMethod]
+	public void ChunkEvenlyDivisibleSequenceTest()
+	{
+		IEnumerable<int> values = [1, 2, 3, 4, 5, 6];
+		int[] firstExpected = [1, 2];
+		int[] secondExpected = [3, 4];
+		int[] thirdExpected = [5, 6];
+
+		int[][] chunks = [.. values.Chunk(2)];
+
+		Assert.HasCount(3, chunks);
+		CollectionAssert.AreEqual(firstExpected, chunks[0]);
+		CollectionAssert.AreEqual(secondExpected, chunks[1]);
+		CollectionAssert.AreEqual(thirdExpected, chunks[2]);
+	}
+
+	[TestMethod]
+	public void ChunkNonDivisibleSequenceTest()
+	{
+		IEnumerable<int> values = [1, 2, 3, 4, 5];
+		int[] firstExpected = [1, 2];
+		int[] secondExpected = [3, 4];
+		int[] thirdExpected = [5];
+
+		int[][] chunks = [.. values.Chunk(2)];
+
+		Assert.HasCount(3, chunks);
+		CollectionAssert.AreEqual(firstExpected, chunks[0]);
+		CollectionAssert.AreEqual(secondExpected, chunks[1]);
+		CollectionAssert.AreEqual(thirdExpected, chunks[2]);
+	}
+
+	[TestMethod]
+	public void ChunkSizeLargerThanSequenceTest()
+	{
+		IEnumerable<int> values = [1, 2, 3];
+		int[] expected = [1, 2, 3];
+
+		int[][] chunks = [.. values.Chunk(10)];
+
+		Assert.HasCount(1, chunks);
+		CollectionAssert.AreEqual(expected, chunks[0]);
+	}
+
+	[TestMethod]
+	public void ChunkSizeOfOneTest()
+	{
+		IEnumerable<int> values = [1, 2, 3];
+		int[] firstExpected = [1];
+		int[] secondExpected = [2];
+		int[] thirdExpected = [3];
+
+		int[][] chunks = [.. values.Chunk(1)];
+
+		Assert.HasCount(3, chunks);
+		CollectionAssert.AreEqual(firstExpected, chunks[0]);
+		CollectionAssert.AreEqual(secondExpected, chunks[1]);
+		CollectionAssert.AreEqual(thirdExpected, chunks[2]);
+	}
+
+	[TestMethod]
+	public void ChunkEmptySequenceTest()
+	{
+		IEnumerable<int> values = [];
+
+		int[][] chunks = [.. values.Chunk(3)];
+
+		Assert.IsEmpty(chunks);
+	}
+
+	[TestMethod]
+	public void ChunkNullSequenceThrowsArgumentNullExceptionTest()
+	{
+		IEnumerable<int> values = default!;
+
+		Assert.ThrowsExactly<ArgumentNullException>(() => values.Chunk(2).ToArray());
+	}
+
+	[TestMethod]
+	public void ChunkZeroSizeThrowsArgumentOutOfRangeExceptionTest()
+	{
+		IEnumerable<int> values = [1, 2, 3];
+
+		Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => values.Chunk(0).ToArray());
+	}
+
+	[TestMethod]
+	public void ChunkNegativeSizeThrowsArgumentOutOfRangeExceptionTest()
+	{
+		IEnumerable<int> values = [1, 2, 3];
+
+		Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => values.Chunk(-1).ToArray());
+	}
+}


### PR DESCRIPTION
**Changes:**

- Introduced a `Chunk` extension method to `IEnumerable<T>` for splitting sequences into fixed-size arrays, with support for both .NET 6+ and earlier versions.
- Added input validation and fallback implementation.
- Updated `README` with usage examples and added unit tests for various scenarios.

closes #268 