### PR TITLE
feat(extensions): add `SpanExtensions` with allocation-free span/memory helpers

### DIFF
--- a/src/BB84.Extensions/README.md
+++ b/src/BB84.Extensions/README.md
@@ -110,6 +110,28 @@ TimeOnly value = new(23, 30);
 bool night = value.IsBetween(new TimeOnly(22, 0), new TimeOnly(2, 0)); // true
 ```
 
+### Span and Memory helpers
+
+`SpanExtensions` provides allocation-free helpers for `ReadOnlySpan<T>` and `ReadOnlyMemory<byte>` on `netstandard2.1` and all modern .NET targets.
+
+```csharp
+// IsEmpty — readable alias for Length == 0
+ReadOnlySpan<int> empty = ReadOnlySpan<int>.Empty;
+bool isEmpty = empty.IsEmpty();         // true
+
+// TakeRandom — random element without heap allocation
+ReadOnlySpan<int> nums = new int[] { 1, 2, 3 };
+int picked = nums.TakeRandom();
+
+// GetHexString — uppercase hex, mirrors ByteExtensions.GetHexString
+ReadOnlySpan<byte> bytes = new byte[] { 0xFF, 0x0A };
+string hex = bytes.GetHexString();      // "FF0A"
+
+// ToByteArray — convenience conversion from ReadOnlyMemory<byte>
+ReadOnlyMemory<byte> mem = new byte[] { 1, 2, 3, 4 };
+byte[] arr = mem.ToByteArray();
+```
+
 ### Color to RGB hexadecimal representation
 
 The `ToRGBHexString` method turns any `System.Drawing.Color` into its RGB hexadecimal string representation, with the prefix '#'.

--- a/src/BB84.Extensions/SpanExtensions.cs
+++ b/src/BB84.Extensions/SpanExtensions.cs
@@ -1,0 +1,75 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
+using System.Globalization;
+using System.Text;
+
+using BB84.Extensions.Helper;
+
+namespace BB84.Extensions;
+
+/// <summary>
+/// Provides extension methods for <see cref="ReadOnlySpan{T}"/> and
+/// <see cref="ReadOnlyMemory{T}"/>, offering allocation-free helpers that complement
+/// <see cref="ByteExtensions"/> and <see cref="ArrayExtensions"/>.
+/// </summary>
+public static class SpanExtensions
+{
+	/// <summary>
+	/// Determines whether the <paramref name="span"/> contains no elements.
+	/// </summary>
+	/// <typeparam name="T">The type of elements in the span.</typeparam>
+	/// <param name="span">The span to check.</param>
+	/// <returns>
+	/// <see langword="true"/> if <paramref name="span"/> has a length of zero;
+	/// otherwise, <see langword="false"/>.
+	/// </returns>
+	public static bool IsEmpty<T>(this ReadOnlySpan<T> span)
+		=> span.Length == 0;
+
+	/// <summary>
+	/// Returns a randomly selected element from the <paramref name="span"/> without heap
+	/// allocation.
+	/// </summary>
+	/// <typeparam name="T">The type of elements in the span.</typeparam>
+	/// <param name="span">The span from which to select a random element.</param>
+	/// <returns>A randomly selected element from <paramref name="span"/>.</returns>
+	public static T TakeRandom<T>(this ReadOnlySpan<T> span)
+		=> span[RandomHelper.Random.Next(0, span.Length)];
+
+	/// <summary>
+	/// Converts the <paramref name="span"/> to its uppercase hexadecimal string representation,
+	/// mirroring the behavior of <see cref="ByteExtensions.GetHexString"/>.
+	/// </summary>
+	/// <remarks>
+	/// Each byte is represented as two uppercase hexadecimal characters. The resulting string
+	/// contains no separators.
+	/// </remarks>
+	/// <param name="span">The span of bytes to convert.</param>
+	/// <returns>
+	/// A string containing the uppercase hexadecimal representation of <paramref name="span"/>.
+	/// </returns>
+	public static string GetHexString(this ReadOnlySpan<byte> span)
+	{
+#if NET6_0_OR_GREATER
+		return Convert.ToHexString(span);
+#else
+		StringBuilder sb = new();
+		foreach (byte b in span)
+			_ = sb.Append(b.ToString("X2", CultureInfo.InvariantCulture));
+		return sb.ToString();
+#endif
+	}
+
+	/// <summary>
+	/// Copies the contents of <paramref name="memory"/> into a new <see cref="byte"/> array.
+	/// </summary>
+	/// <param name="memory">The memory segment to convert.</param>
+	/// <returns>A new <see cref="byte"/>[] containing the data from <paramref name="memory"/>.</returns>
+	public static byte[] ToByteArray(this ReadOnlyMemory<byte> memory)
+		=> memory.ToArray();
+}
+#endif

--- a/tests/BB84.Extensions.Tests/SpanExtensionsTests.GetHexString.cs
+++ b/tests/BB84.Extensions.Tests/SpanExtensionsTests.GetHexString.cs
@@ -1,0 +1,31 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET5_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+public sealed partial class SpanExtensionsTests
+{
+	[TestMethod]
+	public void GetHexStringShouldReturnUppercaseHex()
+	{
+		ReadOnlySpan<byte> span = [0xFF, 0xFF];
+
+		string result = SpanExtensions.GetHexString(span);
+
+		Assert.AreEqual("FFFF", result);
+	}
+
+	[TestMethod]
+	public void GetHexStringWithEmptySpanShouldReturnEmptyString()
+	{
+		ReadOnlySpan<byte> span = [];
+
+		string result = SpanExtensions.GetHexString(span);
+
+		Assert.AreEqual(string.Empty, result);
+	}
+}
+#endif

--- a/tests/BB84.Extensions.Tests/SpanExtensionsTests.IsEmpty.cs
+++ b/tests/BB84.Extensions.Tests/SpanExtensionsTests.IsEmpty.cs
@@ -1,0 +1,31 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET5_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+public sealed partial class SpanExtensionsTests
+{
+	[TestMethod]
+	public void IsEmptyWithEmptySpanShouldReturnTrue()
+	{
+		ReadOnlySpan<int> span = ReadOnlySpan<int>.Empty;
+
+		bool result = SpanExtensions.IsEmpty(span);
+
+		Assert.IsTrue(result);
+	}
+
+	[TestMethod]
+	public void IsEmptyWithNonEmptySpanShouldReturnFalse()
+	{
+		ReadOnlySpan<int> span = new int[] { 1, 2, 3 };
+
+		bool result = SpanExtensions.IsEmpty(span);
+
+		Assert.IsFalse(result);
+	}
+}
+#endif

--- a/tests/BB84.Extensions.Tests/SpanExtensionsTests.TakeRandom.cs
+++ b/tests/BB84.Extensions.Tests/SpanExtensionsTests.TakeRandom.cs
@@ -1,0 +1,22 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET5_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+public sealed partial class SpanExtensionsTests
+{
+	[TestMethod]
+	public void TakeRandomShouldReturnElementFromSpan()
+	{
+		int[] source = [1, 2, 3, 4, 5];
+		ReadOnlySpan<int> span = source;
+
+		int result = SpanExtensions.TakeRandom(span);
+
+		Assert.Contains(result, source);
+	}
+}
+#endif

--- a/tests/BB84.Extensions.Tests/SpanExtensionsTests.ToByteArray.cs
+++ b/tests/BB84.Extensions.Tests/SpanExtensionsTests.ToByteArray.cs
@@ -1,0 +1,32 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET5_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+public sealed partial class SpanExtensionsTests
+{
+	[TestMethod]
+	public void ToByteArrayShouldReturnEquivalentArray()
+	{
+		byte[] source = [1, 2, 3, 4];
+		ReadOnlyMemory<byte> memory = source;
+
+		byte[] result = SpanExtensions.ToByteArray(memory);
+
+		CollectionAssert.AreEqual(source, result);
+	}
+
+	[TestMethod]
+	public void ToByteArrayWithEmptyMemoryShouldReturnEmptyArray()
+	{
+		ReadOnlyMemory<byte> memory = ReadOnlyMemory<byte>.Empty;
+
+		byte[] result = SpanExtensions.ToByteArray(memory);
+
+		Assert.IsEmpty(result);
+	}
+}
+#endif

--- a/tests/BB84.Extensions.Tests/SpanExtensionsTests.cs
+++ b/tests/BB84.Extensions.Tests/SpanExtensionsTests.cs
@@ -1,0 +1,12 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#if NET5_0_OR_GREATER
+namespace BB84.Extensions.Tests;
+
+[TestClass]
+public sealed partial class SpanExtensionsTests
+{ }
+#endif


### PR DESCRIPTION
**Changes:**

- Introduces `SpanExtensions` for `ReadOnlySpan<T>` and `ReadOnlyMemory<byte>` with `IsEmpty`, `TakeRandom`, `GetHexString`, and `ToByteArray` methods.
- Updates README with usage examples and adds unit tests for all new helpers, including edge cases.
- All code is conditionally compiled for supported .NET versions.

closes #269 