### PR TITLE
feat(extensions): add `SHA-256` and `SHA-512` hashing to extensions

### DIFF
--- a/src/BB84.Extensions/ByteExtensions.cs
+++ b/src/BB84.Extensions/ByteExtensions.cs
@@ -17,7 +17,7 @@ namespace BB84.Extensions;
 /// </summary>
 /// <remarks>
 /// This class includes methods for common operations on byte arrays, such as converting to and
-/// from Base64, generating MD5 hashes, and encoding/decoding strings. It also provides utility
+/// from Base64, generating MD5, SHA-256, and SHA-512 hashes, and encoding/decoding strings. It also provides utility
 /// methods for checking nullability and obtaining hexadecimal representations of byte arrays.
 /// </remarks>
 public static partial class ByteExtensions
@@ -168,6 +168,54 @@ public static partial class ByteExtensions
 	/// </returns>
 	public static string GetMD5String(this byte[] value)
 		=> value.GetMD5().GetHexString();
+
+	/// <summary>
+	/// Computes the SHA-256 hash value for the specified byte array.
+	/// </summary>
+	/// <param name="value">The input byte array for which the SHA-256 hash is to be computed.</param>
+	/// <returns>A byte array containing the computed SHA-256 hash value.</returns>
+	public static byte[] GetSHA256(this byte[] value)
+	{
+#if NET8_0_OR_GREATER
+		return SHA256.HashData(value);
+#else
+		return SHA256.Create().ComputeHash(value);
+#endif
+	}
+
+	/// <summary>
+	/// Computes the SHA-256 hash of the specified byte array and returns it as a hexadecimal string.
+	/// </summary>
+	/// <param name="value">The byte array to compute the SHA-256 hash for.</param>
+	/// <returns>
+	/// A string representing the SHA-256 hash of the input byte array in hexadecimal format.
+	/// </returns>
+	public static string GetSHA256String(this byte[] value)
+		=> value.GetSHA256().GetHexString();
+
+	/// <summary>
+	/// Computes the SHA-512 hash value for the specified byte array.
+	/// </summary>
+	/// <param name="value">The input byte array for which the SHA-512 hash is to be computed.</param>
+	/// <returns>A byte array containing the computed SHA-512 hash value.</returns>
+	public static byte[] GetSHA512(this byte[] value)
+	{
+#if NET8_0_OR_GREATER
+		return SHA512.HashData(value);
+#else
+		return SHA512.Create().ComputeHash(value);
+#endif
+	}
+
+	/// <summary>
+	/// Computes the SHA-512 hash of the specified byte array and returns it as a hexadecimal string.
+	/// </summary>
+	/// <param name="value">The byte array to compute the SHA-512 hash for.</param>
+	/// <returns>
+	/// A string representing the SHA-512 hash of the input byte array in hexadecimal format.
+	/// </returns>
+	public static string GetSHA512String(this byte[] value)
+		=> value.GetSHA512().GetHexString();
 
 	/// <summary>
 	/// Converts the specified byte array to a string using the provided encoding.

--- a/src/BB84.Extensions/README.md
+++ b/src/BB84.Extensions/README.md
@@ -132,6 +132,36 @@ ReadOnlyMemory<byte> mem = new byte[] { 1, 2, 3, 4 };
 byte[] arr = mem.ToByteArray();
 ```
 
+### SHA-256 and SHA-512 hashing
+
+`StringExtensions` provides SHA-256 and SHA-512 hashing overloads following the same naming pattern as the existing MD5 methods.
+
+```csharp
+string value = "UnitTest";
+
+// SHA-256
+string sha256Utf8    = value.GetSha256Utf8();
+string sha256Ascii   = value.GetSha256Ascii();
+string sha256Unicode = value.GetSha256Unicode();
+
+// SHA-512
+string sha512Utf8    = value.GetSha512Utf8();
+string sha512Ascii   = value.GetSha512Ascii();
+string sha512Unicode = value.GetSha512Unicode();
+```
+
+`ByteExtensions` exposes the same algorithms directly on byte arrays:
+
+```csharp
+byte[] data = Encoding.UTF8.GetBytes("UnitTest");
+
+byte[] sha256Hash   = data.GetSHA256();
+string sha256String = data.GetSHA256String();
+
+byte[] sha512Hash   = data.GetSHA512();
+string sha512String = data.GetSHA512String();
+```
+
 ### Color to RGB hexadecimal representation
 
 The `ToRGBHexString` method turns any `System.Drawing.Color` into its RGB hexadecimal string representation, with the prefix '#'.

--- a/src/BB84.Extensions/StringExtensions.cs
+++ b/src/BB84.Extensions/StringExtensions.cs
@@ -18,8 +18,8 @@ namespace BB84.Extensions;
 /// <remarks>This <see cref="StringExtensions"/> class includes utility methods for common string
 /// operations such as compressing and decompressing strings, encoding and decoding Base64 strings,
 /// formatting strings with culture-specific options, and checking for null or empty values. It also
-/// provides methods for removing unwanted whitespace or line breaks, and generating MD5 hashes for
-/// strings.
+/// provides methods for removing unwanted whitespace or line breaks, and generating MD5, SHA-256,
+/// and SHA-512 hashes for strings.
 /// </remarks>
 public static partial class StringExtensions
 {
@@ -283,6 +283,78 @@ public static partial class StringExtensions
 		=> GetMd5Bytes(value, Encoding.Unicode).GetHexString();
 
 	/// <summary>
+	/// Computes the SHA-256 hash of the specified string using UTF-8 encoding.
+	/// </summary>
+	/// <remarks>
+	/// This method uses UTF-8 encoding to convert the input string into bytes before computing the
+	/// SHA-256 hash. The resulting hash is returned as a hexadecimal string.
+	/// </remarks>
+	/// <param name="value">The input string to compute the SHA-256 hash for.</param>
+	/// <returns>A hexadecimal string representation of the SHA-256 hash of the input string.</returns>
+	public static string GetSha256Utf8(this string value)
+		=> GetSha256Bytes(value, Encoding.UTF8).GetHexString();
+
+	/// <summary>
+	/// Computes the SHA-256 hash of the specified string using ASCII encoding.
+	/// </summary>
+	/// <remarks>
+	/// This method uses ASCII encoding to convert the input string into bytes before computing the
+	/// SHA-256 hash. The resulting hash is returned as a hexadecimal string.
+	/// </remarks>
+	/// <param name="value">The input string to compute the SHA-256 hash for.</param>
+	/// <returns>A hexadecimal string representation of the SHA-256 hash of the input string.</returns>
+	public static string GetSha256Ascii(this string value)
+		=> GetSha256Bytes(value, Encoding.ASCII).GetHexString();
+
+	/// <summary>
+	/// Computes the SHA-256 hash of the specified string using Unicode encoding.
+	/// </summary>
+	/// <remarks>
+	/// This method uses Unicode encoding to convert the input string into bytes before computing the
+	/// SHA-256 hash. The resulting hash is returned as a hexadecimal string.
+	/// </remarks>
+	/// <param name="value">The input string to compute the SHA-256 hash for.</param>
+	/// <returns>A hexadecimal string representation of the SHA-256 hash of the input string.</returns>
+	public static string GetSha256Unicode(this string value)
+		=> GetSha256Bytes(value, Encoding.Unicode).GetHexString();
+
+	/// <summary>
+	/// Computes the SHA-512 hash of the specified string using UTF-8 encoding.
+	/// </summary>
+	/// <remarks>
+	/// This method uses UTF-8 encoding to convert the input string into bytes before computing the
+	/// SHA-512 hash. The resulting hash is returned as a hexadecimal string.
+	/// </remarks>
+	/// <param name="value">The input string to compute the SHA-512 hash for.</param>
+	/// <returns>A hexadecimal string representation of the SHA-512 hash of the input string.</returns>
+	public static string GetSha512Utf8(this string value)
+		=> GetSha512Bytes(value, Encoding.UTF8).GetHexString();
+
+	/// <summary>
+	/// Computes the SHA-512 hash of the specified string using ASCII encoding.
+	/// </summary>
+	/// <remarks>
+	/// This method uses ASCII encoding to convert the input string into bytes before computing the
+	/// SHA-512 hash. The resulting hash is returned as a hexadecimal string.
+	/// </remarks>
+	/// <param name="value">The input string to compute the SHA-512 hash for.</param>
+	/// <returns>A hexadecimal string representation of the SHA-512 hash of the input string.</returns>
+	public static string GetSha512Ascii(this string value)
+		=> GetSha512Bytes(value, Encoding.ASCII).GetHexString();
+
+	/// <summary>
+	/// Computes the SHA-512 hash of the specified string using Unicode encoding.
+	/// </summary>
+	/// <remarks>
+	/// This method uses Unicode encoding to convert the input string into bytes before computing the
+	/// SHA-512 hash. The resulting hash is returned as a hexadecimal string.
+	/// </remarks>
+	/// <param name="value">The input string to compute the SHA-512 hash for.</param>
+	/// <returns>A hexadecimal string representation of the SHA-512 hash of the input string.</returns>
+	public static string GetSha512Unicode(this string value)
+		=> GetSha512Bytes(value, Encoding.Unicode).GetHexString();
+
+	/// <summary>
 	/// Determines whether the specified nullable string has a null value.
 	/// </summary>
 	/// <param name="value">The nullable string to check.</param>
@@ -403,4 +475,10 @@ public static partial class StringExtensions
 
 	private static byte[] GetMd5Bytes(string stringValue, Encoding encoding)
 		=> encoding.GetBytes(stringValue).GetMD5();
+
+	private static byte[] GetSha256Bytes(string stringValue, Encoding encoding)
+		=> encoding.GetBytes(stringValue).GetSHA256();
+
+	private static byte[] GetSha512Bytes(string stringValue, Encoding encoding)
+		=> encoding.GetBytes(stringValue).GetSHA512();
 }

--- a/tests/BB84.Extensions.Tests/ByteExtensionsTests.GetSHA256.cs
+++ b/tests/BB84.Extensions.Tests/ByteExtensionsTests.GetSHA256.cs
@@ -1,0 +1,15 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.Extensions.Tests;
+
+public partial class ByteExtensionsTests
+{
+	[TestMethod]
+	[DataRow("This is a long test string for testing stuff.", "78AD0FEA85FA4DB12590C0250E28B224DE44C2FE846A10B20632EF586CD31E83")]
+	[DataRow("This is another long test string for testing stuff.", "226D150598387B11979B2F6BEE5306275F9EE96D3F30FE3AD3DE9BABF9174DE0")]
+	public void GetSHA256StringTest(string input, string expected)
+		=> Assert.AreEqual(expected, input.GetBytes().GetSHA256String());
+}

--- a/tests/BB84.Extensions.Tests/ByteExtensionsTests.GetSHA512.cs
+++ b/tests/BB84.Extensions.Tests/ByteExtensionsTests.GetSHA512.cs
@@ -1,0 +1,15 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.Extensions.Tests;
+
+public partial class ByteExtensionsTests
+{
+	[TestMethod]
+	[DataRow("This is a long test string for testing stuff.", "AEBEC276E361BE89B5BB0597908754E1229B17C6E889D802A3B9D34DBE858F02F97DAD118BA4AB6BEC980AE935E5FB542518916102D641A1245D24622B3299D7")]
+	[DataRow("This is another long test string for testing stuff.", "2F2B42A54E6BA48D203C93229957212B0654DC7B92DCECF16D621D580903AA88D73705F83345032AC6C3DE3A885707CB923006AD4AFF83CC6D75133B29D8F632")]
+	public void GetSHA512StringTest(string input, string expected)
+		=> Assert.AreEqual(expected, input.GetBytes().GetSHA512String());
+}

--- a/tests/BB84.Extensions.Tests/StringExtensionsTests.GetSha256.cs
+++ b/tests/BB84.Extensions.Tests/StringExtensionsTests.GetSha256.cs
@@ -1,0 +1,39 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.Extensions.Tests;
+
+public partial class StringExtensionsTests
+{
+	[TestMethod]
+	public void GetSha256Utf8Test()
+	{
+		string value = "UnitTest";
+
+		string result = value.GetSha256Utf8();
+
+		Assert.AreEqual("9F629BE9A63456097B80045FAD64ED7F49EDECCBD689CF69D8CC8296BB5276F3", result);
+	}
+
+	[TestMethod]
+	public void GetSha256AsciiTest()
+	{
+		string value = "UnitTest";
+
+		string result = value.GetSha256Ascii();
+
+		Assert.AreEqual("9F629BE9A63456097B80045FAD64ED7F49EDECCBD689CF69D8CC8296BB5276F3", result);
+	}
+
+	[TestMethod]
+	public void GetSha256UnicodeTest()
+	{
+		string value = "UnitTest";
+
+		string result = value.GetSha256Unicode();
+
+		Assert.AreEqual("0A499BEAB1F54EF055D81FEFD9F93C28BB9088D2E6D79042D487F73A8D6E7B6B", result);
+	}
+}

--- a/tests/BB84.Extensions.Tests/StringExtensionsTests.GetSha512.cs
+++ b/tests/BB84.Extensions.Tests/StringExtensionsTests.GetSha512.cs
@@ -1,0 +1,39 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.Extensions.Tests;
+
+public partial class StringExtensionsTests
+{
+	[TestMethod]
+	public void GetSha512Utf8Test()
+	{
+		string value = "UnitTest";
+
+		string result = value.GetSha512Utf8();
+
+		Assert.AreEqual("E67958D980D4534131BA29EE59DEF22DF37656D8D433F7AF5667E7E88BC38282325EE4BD278827BC5376466A5F753E0CB8ABF7768EF8B4B819F32A64AA585EBB", result);
+	}
+
+	[TestMethod]
+	public void GetSha512AsciiTest()
+	{
+		string value = "UnitTest";
+
+		string result = value.GetSha512Ascii();
+
+		Assert.AreEqual("E67958D980D4534131BA29EE59DEF22DF37656D8D433F7AF5667E7E88BC38282325EE4BD278827BC5376466A5F753E0CB8ABF7768EF8B4B819F32A64AA585EBB", result);
+	}
+
+	[TestMethod]
+	public void GetSha512UnicodeTest()
+	{
+		string value = "UnitTest";
+
+		string result = value.GetSha512Unicode();
+
+		Assert.AreEqual("FB2F0779A02DE57B50ABFD2A6F3DBA321A30F371A987D3EB93B7A1D98CD0C9714F166C664028A5E32CC20B4CB82EB9D5CCACBE301C833D824DAF819E49006C9F", result);
+	}
+}


### PR DESCRIPTION
**Changes:**

- Added `SHA-256` and `SHA-512` support to `ByteExtensions` and `StringExtensions`, including methods for byte array and hex string output.
- Added helper methods and comprehensive unit tests for all new hashing methods and encodings.
- Updated documentation and `README` with usage examples.

closes #264 