### PR TITLE
feat(extensions): add async `Stream.ToByteArrayAsync` extension and tests

### DIFF
--- a/src/BB84.Extensions/README.md
+++ b/src/BB84.Extensions/README.md
@@ -132,6 +132,20 @@ ReadOnlyMemory<byte> mem = new byte[] { 1, 2, 3, 4 };
 byte[] arr = mem.ToByteArray();
 ```
 
+### Stream to byte array
+
+The `ToByteArray` method reads the entire content of a `Stream` into a byte array. The async
+counterpart `ToByteArrayAsync` does the same without blocking the calling thread and supports
+cancellation.
+
+```csharp
+// synchronous
+byte[] bytes = stream.ToByteArray();
+
+// asynchronous
+byte[] bytes = await stream.ToByteArrayAsync(cancellationToken);
+```
+
 ### SHA-256 and SHA-512 hashing
 
 `StringExtensions` provides SHA-256 and SHA-512 hashing overloads following the same naming pattern as the existing MD5 methods.

--- a/src/BB84.Extensions/StreamExtensions.cs
+++ b/src/BB84.Extensions/StreamExtensions.cs
@@ -10,7 +10,8 @@ namespace BB84.Extensions;
 /// </summary>
 /// <remarks>
 /// This class contains utility methods that extend the functionality of the <see cref="Stream"/>
-/// class, enabling common operations such as converting a stream to a byte array.
+/// class, enabling common operations such as converting a stream to a byte array synchronously
+/// or asynchronously.
 /// </remarks>
 public static class StreamExtensions
 {
@@ -33,6 +34,30 @@ public static class StreamExtensions
 		using MemoryStream memoryStream = new();
 		while ((read = inputStream.Read(buffer, 0, buffer.Length)) > 0)
 			memoryStream.Write(buffer, 0, read);
+		return memoryStream.ToArray();
+	}
+
+	/// <summary>
+	/// Asynchronously converts the contents of the specified <see cref="Stream"/> to a byte array.
+	/// </summary>
+	/// <remarks>
+	/// The method reads the entire content of the <paramref name="inputStream"/> asynchronously
+	/// and returns it as a byte array. The position of the <paramref name="inputStream"/> is
+	/// advanced as the data is read.
+	/// </remarks>
+	/// <param name="inputStream">The input <see cref="Stream"/> to read from.</param>
+	/// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+	/// <returns>
+	/// A task that represents the asynchronous operation. The task result contains a byte array
+	/// with the data read from the <paramref name="inputStream"/>.
+	/// </returns>
+	public static async Task<byte[]> ToByteArrayAsync(this Stream inputStream, CancellationToken cancellationToken = default)
+	{
+		using MemoryStream memoryStream = new();
+		
+		await inputStream.CopyToAsync(memoryStream, 16 * 1024, cancellationToken)
+			.ConfigureAwait(false);
+		
 		return memoryStream.ToArray();
 	}
 }

--- a/tests/BB84.Extensions.Tests/StreamExtensionsTests.ToByteArrayAsync.cs
+++ b/tests/BB84.Extensions.Tests/StreamExtensionsTests.ToByteArrayAsync.cs
@@ -1,0 +1,35 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.Extensions.Tests;
+
+public sealed partial class StreamExtensionsTests
+{
+	[TestMethod]
+	[DynamicData(nameof(GetData))]
+	public async Task ToByteArrayAsyncTest(byte[] buffer)
+	{
+		using CancellationTokenSource cts = new();
+		MemoryStream stream = new(buffer);
+
+		byte[] result = await stream
+			.ToByteArrayAsync(cts.Token)
+			.ConfigureAwait(false);
+
+		Assert.IsTrue(result.SequenceEqual(buffer));
+	}
+
+	[TestMethod]
+	public async Task ToByteArrayAsyncCancelledTest()
+	{
+		using CancellationTokenSource cts = new();
+		cts.Cancel();
+
+		MemoryStream stream = new([1, 2, 3]);
+
+		await Assert.ThrowsAsync<OperationCanceledException>(
+			() => stream.ToByteArrayAsync(cts.Token)).ConfigureAwait(false);
+	}
+}


### PR DESCRIPTION
**Changes:**

- Added `ToByteArrayAsync` extension for `Stream` with cancellation support.
- Added unit tests for async conversion and cancellation scenarios.
- Updated XML docs and `README` with usage examples.

closes #265 